### PR TITLE
Added Connection Scope support for OAuth2 connections

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -50,6 +50,10 @@ class ViewController: UIViewController {
                     .classic()
                     .withOptions {
                         applyDefaultOptions(&$0)
+                        $0.customSignupFields = [
+                            CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle)),
+                            CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle))
+                        ]
                     }
                     .withStyle {
                         $0.oauth2["slack"] = AuthStyle(
@@ -57,7 +61,7 @@ class ViewController: UIViewController {
                             color: UIColor ( red: 0.4118, green: 0.8078, blue: 0.6588, alpha: 1.0 ),
                             withImage: LazyImage(name: "ic_slack")
                         )
-                    }
+                }
             },
             actionButton(withTitle: "LOGIN WITH CUSTOM STYLE") {
                 return Lock

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "auth0/Auth0.swift" "feature_webauth_spawn"
+github "auth0/Auth0.swift" ~>1.3.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "auth0/Auth0.swift" ~> 1.2
+github "auth0/Auth0.swift" "feature_webauth_spawn"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "auth0/Auth0.swift" "da05010e27911b84bf362d7c9ffa92a2b3eee152"
+github "auth0/Auth0.swift" "1.3.0"
 github "emaloney/CleanroomASL" "2.1.2"
 github "Quick/Nimble" "v5.1.1"
 github "AliSoftware/OHHTTPStubs" "5.2.2-swift3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "auth0/Auth0.swift" "1.2.0"
+github "auth0/Auth0.swift" "da05010e27911b84bf362d7c9ffa92a2b3eee152"
 github "emaloney/CleanroomASL" "2.1.2"
 github "Quick/Nimble" "v5.1.1"
 github "AliSoftware/OHHTTPStubs" "5.2.2-swift3"

--- a/Lock.xcodeproj/project.pbxproj
+++ b/Lock.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		5B0CF2DE1DE9B4AF00F82BF4 /* DatabaseUserCreatorErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0CF2DC1DE9B47C00F82BF4 /* DatabaseUserCreatorErrorSpec.swift */; };
 		5B2826431E32297E00E48467 /* NativeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2826421E32297E00E48467 /* NativeHandler.swift */; };
 		5B2981781DD51A460062535C /* InfoBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2981771DD51A460062535C /* InfoBarView.swift */; };
-		5B4177431E44827B007843EA /* Auth0OAuth2InteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F92C68A1D4FE90F00CCE6C0 /* Auth0OAuth2InteractorSpec.swift */; };
+		5B3DA2561E6ED92F00370C17 /* Auth0OAuth2InteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F92C68A1D4FE90F00CCE6C0 /* Auth0OAuth2InteractorSpec.swift */; };
 		5B4DE0151DD66DE1004C8AC2 /* EnterpriseDomainInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4DE0141DD66DE1004C8AC2 /* EnterpriseDomainInteractor.swift */; };
 		5B4DE0171DD67064004C8AC2 /* EnterpriseActiveAuthPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4DE0161DD67064004C8AC2 /* EnterpriseActiveAuthPresenter.swift */; };
 		5B4DE0191DD670F7004C8AC2 /* EnterpriseActiveAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4DE0181DD670F7004C8AC2 /* EnterpriseActiveAuthView.swift */; };
@@ -25,7 +25,7 @@
 		5B55F3CB1E242A2E00B75CF5 /* UnrecoverableErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B55F3CA1E242A2E00B75CF5 /* UnrecoverableErrorPresenter.swift */; };
 		5B55F3D11E244B8700B75CF5 /* UnrecoverableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B55F3D01E244B8700B75CF5 /* UnrecoverableError.swift */; };
 		5B55F3D41E24FFD000B75CF5 /* UnrecoverableErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B55F3D21E24F3F000B75CF5 /* UnrecoverableErrorSpec.swift */; };
-		5B6631531DDB9B28001CB043 /* EnterpriseDomainInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6631511DDB990B001CB043 /* EnterpriseDomainInteractorSpec.swift */; };
+		5B889AEC1E6EE8C400C9FBAF /* EnterpriseDomainInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6631511DDB990B001CB043 /* EnterpriseDomainInteractorSpec.swift */; };
 		5BA563F11DD117550002D3AB /* EnterpriseActiveAuthInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA563EF1DD1171F0002D3AB /* EnterpriseActiveAuthInteractorSpec.swift */; };
 		5BB4A7C11DF9A38E008E8C37 /* DatabaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB4A7C01DF9A38E008E8C37 /* DatabaseView.swift */; };
 		5BCDE1361DDDF17F00AA2A6C /* EnterpriseActiveAuthPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCDE1341DDDF12100AA2A6C /* EnterpriseActiveAuthPresenterSpec.swift */; };
@@ -1055,11 +1055,12 @@
 				5F6C01551D91656100198ACD /* UsernameValidatorSpec.swift in Sources */,
 				5F2496BE1D67ADB300A1C6E2 /* EmailValidatorSpec.swift in Sources */,
 				5B0CF2D61DE9AE0F00F82BF4 /* InputValidationErrorSpec.swift in Sources */,
-				5B4177431E44827B007843EA /* Auth0OAuth2InteractorSpec.swift in Sources */,
+				5B3DA2561E6ED92F00370C17 /* Auth0OAuth2InteractorSpec.swift in Sources */,
 				5FBE5CCA1D3EA1380038536D /* MultifactorPresenterSpec.swift in Sources */,
 				5BA563F11DD117550002D3AB /* EnterpriseActiveAuthInteractorSpec.swift in Sources */,
 				5F92C68D1D50E47100CCE6C0 /* AuthStyleSpec.swift in Sources */,
 				5F5090081D1DE7BA00EAA650 /* NetworkStub.swift in Sources */,
+				5B889AEC1E6EE8C400C9FBAF /* EnterpriseDomainInteractorSpec.swift in Sources */,
 				5F0FCF921E201CF300E3D53B /* ObserverStoreSpec.swift in Sources */,
 				5B55F3D41E24FFD000B75CF5 /* UnrecoverableErrorSpec.swift in Sources */,
 				5F73CDDC1D309BE900D8D8D1 /* DatabasePasswordInteractorSpec.swift in Sources */,
@@ -1084,7 +1085,6 @@
 				5F50900A1D1DEE9A00EAA650 /* Constants.swift in Sources */,
 				5FE50DBD1D79B8AD00D82290 /* CDNLoaderInteractorSpec.swift in Sources */,
 				5F390E8D1D63B99300FC549C /* LoggerSpec.swift in Sources */,
-				5B6631531DDB9B28001CB043 /* EnterpriseDomainInteractorSpec.swift in Sources */,
 				5B0CF2DE1DE9B4AF00F82BF4 /* DatabaseUserCreatorErrorSpec.swift in Sources */,
 				5F2037C21D5D02880005D2E2 /* Matchers.swift in Sources */,
 				5FEEE81E1DB84BBB00B4DFED /* PasswordPolicySpec.swift in Sources */,

--- a/Lock/Auth0OAuth2Interactor.swift
+++ b/Lock/Auth0OAuth2Interactor.swift
@@ -25,7 +25,7 @@ import Auth0
 
 struct Auth0OAuth2Interactor: OAuth2Authenticatable {
 
-    let webAuth: Auth0.WebAuth
+    let authentication: Authentication
     let dispatcher: Dispatcher
     let options: Options
     let nativeHandlers: [String: AuthProvider]
@@ -41,13 +41,19 @@ struct Auth0OAuth2Interactor: OAuth2Authenticatable {
     private func webAuth(withConnection connection: String, callback: @escaping (OAuth2AuthenticatableError?) -> Void) {
         var parameters: [String: String] = [:]
         self.options.parameters.forEach { parameters[$0] = "\($1)" }
-        var auth = self.webAuth
-            .connection(connection)
+
+        var auth = authentication.webAuth(withConnection: connection)
             .scope(self.options.scope)
             .parameters(parameters)
 
+        _ = auth.logging(enabled: self.options.logHttpRequest)
+
         if let audience = self.options.audience {
             auth = auth.audience(audience)
+        }
+
+        if let connectionScope = self.options.connectionScope[connection] {
+            auth = auth.connectionScope(connectionScope)
         }
 
         auth

--- a/Lock/Auth0OAuth2Interactor.swift
+++ b/Lock/Auth0OAuth2Interactor.swift
@@ -46,7 +46,7 @@ struct Auth0OAuth2Interactor: OAuth2Authenticatable {
             .scope(self.options.scope)
             .parameters(parameters)
 
-        _ = auth.logging(enabled: self.options.logHttpRequest)
+        auth = auth.logging(enabled: self.options.logHttpRequest)
 
         if let audience = self.options.audience {
             auth = auth.audience(audience)

--- a/Lock/LockOptions.swift
+++ b/Lock/LockOptions.swift
@@ -31,6 +31,7 @@ struct LockOptions: OptionBuildable {
     var loggerOutput: LoggerOutput?
     var logHttpRequest: Bool = false
     var scope: String = "openid"
+    var connectionScope: [String: String] = [:]
     var parameters: [String : Any] = [:]
     var allow: DatabaseMode = [.Login, .Signup, .ResetPassword]
     var autoClose: Bool = true

--- a/Lock/OptionBuildable.swift
+++ b/Lock/OptionBuildable.swift
@@ -48,7 +48,7 @@ public protocol OptionBuildable: Options {
         /// Scope used for authentication. By default is `openid`.
     var scope: String { get set }
 
-        /// Allows you to specify provider scopes for oauth2/social connections with a comma separated list. By default is empty.
+        /// Allows you to specify provider scopes for oauth2/social connections with a comma separated list (values depend on the social IdP). By default is empty.
     var connectionScope: [String: String] { get set }
 
         /// Authentication parameters sent with every authentication requests. By default is an empty dictionary.

--- a/Lock/OptionBuildable.swift
+++ b/Lock/OptionBuildable.swift
@@ -48,6 +48,9 @@ public protocol OptionBuildable: Options {
         /// Scope used for authentication. By default is `openid`.
     var scope: String { get set }
 
+        /// Allows you to specify provider scopes for oauth2/social connections with a comma separated list. By default is empty.
+    var connectionScope: [String: String] { get set }
+
         /// Authentication parameters sent with every authentication requests. By default is an empty dictionary.
     var parameters: [String: Any] { get set }
 

--- a/Lock/Options.swift
+++ b/Lock/Options.swift
@@ -33,6 +33,7 @@ public protocol Options {
     var logHttpRequest: Bool { get }
 
     var scope: String { get }
+    var connectionScope: [String: String] { get }
     var parameters: [String: Any] { get }
     var allow: DatabaseMode { get }
     var autoClose: Bool { get }

--- a/Lock/Router.swift
+++ b/Lock/Router.swift
@@ -64,11 +64,11 @@ struct Router: Navigable {
                 let interactor = DatabaseInteractor(connection: database, authentication: authentication, user: self.user, options: self.lock.options, dispatcher: lock.observerStore)
                 let presenter = DatabasePresenter(interactor: interactor, connection: database, navigator: self, options: self.lock.options)
                 if !oauth2.isEmpty {
-                    let interactor = Auth0OAuth2Interactor(webAuth: self.lock.webAuth, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
+                    let interactor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
                     presenter.authPresenter = AuthPresenter(connections: oauth2, interactor: interactor, customStyle: self.lock.style.oauth2)
                 }
                 if !enterprise.isEmpty {
-                    let authInteractor = Auth0OAuth2Interactor(webAuth: self.lock.webAuth, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
+                    let authInteractor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
                     let interactor = EnterpriseDomainInteractor(connections: connections, user: self.user, authentication: authInteractor)
                     presenter.enterpriseInteractor = interactor
                 }
@@ -80,17 +80,17 @@ struct Router: Navigable {
                 // Single Enterprise with support for passive auth only (web auth) and some social connections
             case (nil, let oauth2, let enterprise) where enterprise.hasJustOne(andNotIn: whitelistForActiveAuth):
                 guard let connection = enterprise.first else { return nil }
-                let authInteractor = Auth0OAuth2Interactor(webAuth: self.lock.webAuth, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
+                let authInteractor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
                 let connections: [OAuth2Connection] = oauth2 + [connection]
                 return AuthPresenter(connections: connections, interactor: authInteractor, customStyle: self.lock.style.oauth2)
                 // Social connections only
             case (nil, let oauth2, let enterprise) where enterprise.isEmpty:
-                let interactor = Auth0OAuth2Interactor(webAuth: self.lock.webAuth, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
+                let interactor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
                 let presenter = AuthPresenter(connections: oauth2, interactor: interactor, customStyle: self.lock.style.oauth2)
                 return presenter
                 // Multiple enterprise connections and maybe some social
             case (nil, let oauth2, let enterprise) where !enterprise.isEmpty:
-                let authInteractor = Auth0OAuth2Interactor(webAuth: self.lock.webAuth, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
+                let authInteractor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
                 let interactor = EnterpriseDomainInteractor(connections: connections, user: self.user, authentication: authInteractor)
                 let presenter = EnterpriseDomainPresenter(interactor: interactor, navigator: self, options: self.lock.options)
                 if !oauth2.isEmpty {

--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ Scope used for authentication. By default is `openid`. It will return not only t
 }
 ```
 
+#### Connection Scope
+
+Allows you to set provider scopes for oauth2/social connections with a comma separated list. By default is empty.
+
+```swift
+.withOptions {
+  $0.connectionScope = ["facebook": "user_friends,email"]
+}
+```
+
 #### Database
 
 * **allow**: Which database screens will be accessible, the default is enable all screens e.g. `.Login, .Signup, .ResetPassword`


### PR DESCRIPTION
Added Connection Scope support for OAuth2 connections
Options - Added 'connectionScope'
OAuth2 WebAuth spawns new instance on Login using Authentication.webAuth()
Auth0Auth & EnterpriseDomain Interactors WebAuth param now Authentication
Testing - Added MockAuthentication, Refactored OAuth2 related tests
Docs - Added ConnectScope