### PR TITLE
Added Custom Rule Error support 

### DIFF
--- a/Lock.xcodeproj/project.pbxproj
+++ b/Lock.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		5B0971801DC8F5C4003AA88F /* EnterpriseDomainPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B09717F1DC8F5C4003AA88F /* EnterpriseDomainPresenter.swift */; };
 		5B0971821DC8FAC5003AA88F /* EnterpriseDomainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0971811DC8FAC5003AA88F /* EnterpriseDomainView.swift */; };
 		5B0CF2D61DE9AE0F00F82BF4 /* InputValidationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0CF2D41DE9ADF900F82BF4 /* InputValidationErrorSpec.swift */; };
-		5B0CF2D91DE9B1DB00F82BF4 /* DatabaseAuthenticatableErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0CF2D71DE9B14000F82BF4 /* DatabaseAuthenticatableErrorSpec.swift */; };
+		5B0CF2D91DE9B1DB00F82BF4 /* CredentialAuthErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0CF2D71DE9B14000F82BF4 /* CredentialAuthErrorSpec.swift */; };
 		5B0CF2DE1DE9B4AF00F82BF4 /* DatabaseUserCreatorErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0CF2DC1DE9B47C00F82BF4 /* DatabaseUserCreatorErrorSpec.swift */; };
 		5B1FD96D1E4E2B6B0055C1AC /* PasswordlessActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD96C1E4E2B6B0055C1AC /* PasswordlessActivity.swift */; };
 		5B1FD9701E4E2F170055C1AC /* PasswordlessActivitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1FD96E1E4E2E670055C1AC /* PasswordlessActivitySpec.swift */; };
@@ -239,7 +239,7 @@
 		5B09717F1DC8F5C4003AA88F /* EnterpriseDomainPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnterpriseDomainPresenter.swift; path = Lock/EnterpriseDomainPresenter.swift; sourceTree = SOURCE_ROOT; };
 		5B0971811DC8FAC5003AA88F /* EnterpriseDomainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnterpriseDomainView.swift; path = Lock/EnterpriseDomainView.swift; sourceTree = SOURCE_ROOT; };
 		5B0CF2D41DE9ADF900F82BF4 /* InputValidationErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputValidationErrorSpec.swift; sourceTree = "<group>"; };
-		5B0CF2D71DE9B14000F82BF4 /* DatabaseAuthenticatableErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAuthenticatableErrorSpec.swift; sourceTree = "<group>"; };
+		5B0CF2D71DE9B14000F82BF4 /* CredentialAuthErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialAuthErrorSpec.swift; sourceTree = "<group>"; };
 		5B0CF2DC1DE9B47C00F82BF4 /* DatabaseUserCreatorErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseUserCreatorErrorSpec.swift; sourceTree = "<group>"; };
 		5B1FD96C1E4E2B6B0055C1AC /* PasswordlessActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordlessActivity.swift; sourceTree = "<group>"; };
 		5B1FD96E1E4E2E670055C1AC /* PasswordlessActivitySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordlessActivitySpec.swift; sourceTree = "<group>"; };
@@ -458,7 +458,7 @@
 			isa = PBXGroup;
 			children = (
 				5B0CF2D41DE9ADF900F82BF4 /* InputValidationErrorSpec.swift */,
-				5B0CF2D71DE9B14000F82BF4 /* DatabaseAuthenticatableErrorSpec.swift */,
+				5B0CF2D71DE9B14000F82BF4 /* CredentialAuthErrorSpec.swift */,
 				5B0CF2DC1DE9B47C00F82BF4 /* DatabaseUserCreatorErrorSpec.swift */,
 				5BB78CC01E54BC2D0074DFE3 /* PasswordlessAuthenticatableErrorSpec.swift */,
 				5B55F3D21E24F3F000B75CF5 /* UnrecoverableErrorSpec.swift */,
@@ -1290,7 +1290,7 @@
 				5F57DFCE1D4FBE5A00C54DA8 /* AuthPresenterSpec.swift in Sources */,
 				5F92C6911D510AFE00CCE6C0 /* LazyImageSpec.swift in Sources */,
 				5BCED4C71DD1FEAA00E2CE8A /* EnterpriseDomainPresenterSpec.swift in Sources */,
-				5B0CF2D91DE9B1DB00F82BF4 /* DatabaseAuthenticatableErrorSpec.swift in Sources */,
+				5B0CF2D91DE9B1DB00F82BF4 /* CredentialAuthErrorSpec.swift in Sources */,
 				5FF0B22A1E1864FE00A73257 /* StyleSpec.swift in Sources */,
 				5F50900A1D1DEE9A00EAA650 /* Constants.swift in Sources */,
 				5B3440CB1E7C11E7009F8BF7 /* ClassicRouterSpec.swift in Sources */,

--- a/Lock/CredentialAuthError.swift
+++ b/Lock/CredentialAuthError.swift
@@ -32,6 +32,7 @@ enum CredentialAuthError: Error, LocalizableError {
     case tooManyAttempts
     case multifactorRequired
     case multifactorInvalid
+    case customRuleFailure(cause: String)
 
     var localizableMessage: String {
         switch self {
@@ -47,6 +48,8 @@ enum CredentialAuthError: Error, LocalizableError {
             return "YOUR ACCOUNT HAS BEEN BLOCKED AFTER MULTIPLE CONSECUTIVE LOGIN ATTEMPTS.".i18n(key: "com.auth0.lock.error.authentication.too_many_attempts", comment: "too_many_attempts")
         case .multifactorInvalid:
             return "WRONG CODE.".i18n(key: "com.auth0.lock.error.authentication.mfa_invalid_code", comment: "a0.mfa_invalid_code")
+        case .customRuleFailure(let cause):
+            return cause
         default:
             return "WE'RE SORRY, SOMETHING WENT WRONG WHEN ATTEMPTING TO LOG IN.".i18n(key: "com.auth0.lock.error.authentication.fallback", comment: "Generic login error")
         }

--- a/Lock/CredentialAuthError.swift
+++ b/Lock/CredentialAuthError.swift
@@ -67,6 +67,21 @@ enum CredentialAuthError: Error, LocalizableError {
 
 extension CredentialAuthError: Equatable {
     static func ==(lhs: CredentialAuthError, rhs: CredentialAuthError) -> Bool {
-        return lhs.localizableMessage == rhs.localizableMessage
+        switch (lhs, rhs) {
+        case (.nonValidInput, .nonValidInput),
+             (.userBlocked, .userBlocked),
+             (.invalidEmailPassword, .invalidEmailPassword),
+             (.couldNotLogin, .couldNotLogin),
+             (.passwordChangeRequired, .passwordChangeRequired),
+             (.passwordLeaked, .passwordLeaked),
+             (.tooManyAttempts, .tooManyAttempts),
+             (.multifactorRequired, .multifactorRequired),
+             (.multifactorInvalid, .multifactorInvalid):
+            return true
+        case (.customRuleFailure(let lhsCause), .customRuleFailure(let rhsCause)):
+            return lhsCause == rhsCause
+        default:
+            return false
+        }
     }
 }

--- a/Lock/CredentialAuthError.swift
+++ b/Lock/CredentialAuthError.swift
@@ -64,24 +64,3 @@ enum CredentialAuthError: Error, LocalizableError {
         }
     }
 }
-
-extension CredentialAuthError: Equatable {
-    static func ==(lhs: CredentialAuthError, rhs: CredentialAuthError) -> Bool {
-        switch (lhs, rhs) {
-        case (.nonValidInput, .nonValidInput),
-             (.userBlocked, .userBlocked),
-             (.invalidEmailPassword, .invalidEmailPassword),
-             (.couldNotLogin, .couldNotLogin),
-             (.passwordChangeRequired, .passwordChangeRequired),
-             (.passwordLeaked, .passwordLeaked),
-             (.tooManyAttempts, .tooManyAttempts),
-             (.multifactorRequired, .multifactorRequired),
-             (.multifactorInvalid, .multifactorInvalid):
-            return true
-        case (.customRuleFailure(let lhsCause), .customRuleFailure(let rhsCause)):
-            return lhsCause == rhsCause
-        default:
-            return false
-        }
-    }
-}

--- a/Lock/CredentialAuthError.swift
+++ b/Lock/CredentialAuthError.swift
@@ -64,3 +64,9 @@ enum CredentialAuthError: Error, LocalizableError {
         }
     }
 }
+
+extension CredentialAuthError: Equatable {
+    static func ==(lhs: CredentialAuthError, rhs: CredentialAuthError) -> Bool {
+        return lhs.localizableMessage == rhs.localizableMessage
+    }
+}

--- a/Lock/DatabaseAuthenticable.swift
+++ b/Lock/DatabaseAuthenticable.swift
@@ -66,6 +66,10 @@ extension CredentialAuthenticatable {
             self.logger.error("Blocked user <\(identifier)>")
             callback(.userBlocked)
             self.dispatcher.dispatch(result: .error(CredentialAuthError.userBlocked))
+        case .failure(let cause as AuthenticationError) where cause.isRuleError:
+            self.logger.error("Failed login of user <\(identifier)> by custom rule")
+            callback(.customRuleFailure(cause: cause.description))
+            self.dispatcher.dispatch(result: .error(CredentialAuthError.customRuleFailure(cause: cause.description)))
         case .failure(let cause as AuthenticationError) where cause.code == "password_change_required":
             self.logger.error("Change password required for user <\(identifier)>")
             callback(.passwordChangeRequired)

--- a/LockTests/CredentialAuthErrorSpec.swift
+++ b/LockTests/CredentialAuthErrorSpec.swift
@@ -87,3 +87,24 @@ class CredentialAuthErrorSpec: QuickSpec {
 
     }
 }
+
+extension CredentialAuthError: Equatable {
+    public static func ==(lhs: CredentialAuthError, rhs: CredentialAuthError) -> Bool {
+        switch (lhs, rhs) {
+        case (.nonValidInput, .nonValidInput),
+             (.userBlocked, .userBlocked),
+             (.invalidEmailPassword, .invalidEmailPassword),
+             (.couldNotLogin, .couldNotLogin),
+             (.passwordChangeRequired, .passwordChangeRequired),
+             (.passwordLeaked, .passwordLeaked),
+             (.tooManyAttempts, .tooManyAttempts),
+             (.multifactorRequired, .multifactorRequired),
+             (.multifactorInvalid, .multifactorInvalid):
+            return true
+        case (.customRuleFailure(let lhsCause), .customRuleFailure(let rhsCause)):
+            return lhsCause == rhsCause
+        default:
+            return false
+        }
+    }
+}

--- a/LockTests/Interactors/DatabaseInteractorSpec.swift
+++ b/LockTests/Interactors/DatabaseInteractorSpec.swift
@@ -566,6 +566,18 @@ class DatabaseInteractorSpec: QuickSpec {
                     }
                 }
             }
+
+            it("should indicate that a custom rule prevented the user from logging in") {
+                stub(condition: databaseLogin(identifier: email, password: password, connection: connection)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                try! database.update(.email, value: email)
+                try! database.update(.password(enforcePolicy: false), value: password)
+                waitUntil(timeout: 2) { done in
+                    database.login { error in
+                        expect(error) == .customRuleFailure(cause: "Only admins can use this")
+                        done()
+                    }
+                }
+            }
         }
 
         describe("login OIDC Conformant") {
@@ -735,6 +747,18 @@ class DatabaseInteractorSpec: QuickSpec {
                 waitUntil(timeout: 2) { done in
                     database.login { error in
                         expect(error) == .passwordLeaked
+                        done()
+                    }
+                }
+            }
+
+            it("should indicate that a custom rule prevented the user from logging in") {
+                stub(condition: realmLogin(identifier: email, password: password, realm: connection)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                try! database.update(.email, value: email)
+                try! database.update(.password(enforcePolicy: false), value: password)
+                waitUntil(timeout: 2) { done in
+                    database.login { error in
+                        expect(error) == .customRuleFailure(cause: "Only admins can use this")
                         done()
                     }
                 }

--- a/LockTests/Interactors/EnterpriseActiveAuthInteractorSpec.swift
+++ b/LockTests/Interactors/EnterpriseActiveAuthInteractorSpec.swift
@@ -219,6 +219,17 @@ class EnterpriseActiveAuthInteractorSpec: QuickSpec {
                 }
             }
 
+            it("should indicate that a custom rule prevented the user from logging in") {
+                stub(condition: databaseLogin(identifier: email, password: password, connection: interactor.connection.name)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                try! interactor.update(.email, value: email)
+                try! interactor.update(.password(enforcePolicy: false), value: password)
+                waitUntil(timeout: 2) { done in
+                    interactor.login { error in
+                        expect(error) == .customRuleFailure(cause: "Only admins can use this")
+                        done()
+                    }
+                }
+            }
         }
 
         describe ("login OIDC Conformnat") {
@@ -308,6 +319,17 @@ class EnterpriseActiveAuthInteractorSpec: QuickSpec {
                 }
             }
             
+            it("should indicate that a custom rule prevented the user from logging in") {
+                stub(condition: realmLogin(identifier: email, password: password, realm: interactor.connection.name)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                try! interactor.update(.email, value: email)
+                try! interactor.update(.password(enforcePolicy: false), value: password)
+                waitUntil(timeout: 2) { done in
+                    interactor.login { error in
+                        expect(error) == .customRuleFailure(cause: "Only admins can use this")
+                        done()
+                    }
+                }
+            }
         }
         
     }

--- a/LockTests/Interactors/MultifactorInteractorSpec.swift
+++ b/LockTests/Interactors/MultifactorInteractorSpec.swift
@@ -156,6 +156,16 @@ class MultifactorInteractorSpec: QuickSpec {
                 }
             }
             
+            it("should indicate that a custom rule prevented the user from logging in") {
+                stub(condition: databaseLogin(identifier: email, password: password, code: code, connection: connection.name)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                try! interactor.setMultifactorCode(code)
+                waitUntil(timeout: 2) { done in
+                    interactor.login { error in
+                        expect(error) == .customRuleFailure(cause: "Only admins can use this")
+                        done()
+                    }
+                }
+            }
         }
 
     }

--- a/LockTests/Interactors/PasswordlessInteractorSpec.swift
+++ b/LockTests/Interactors/PasswordlessInteractorSpec.swift
@@ -177,6 +177,18 @@ class PasswordlessInteractorSpec: QuickSpec {
                         }
                     }
                 }
+                
+                it("should indicate that a custom rule prevented the user from logging in") {
+                    stub(condition: databaseLogin(identifier: email, password: code, connection: connection.name)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                    try! interactor.update(.email, value: email)
+                    try! interactor.update(.oneTimePassword, value: code)
+                    waitUntil(timeout: 2) { done in
+                        interactor.login(connection.name) { error in
+                            expect(error) == .customRuleFailure(cause: "Only admins can use this")
+                            done()
+                        }
+                    }
+                }
             }
 
             describe("request") {
@@ -393,6 +405,18 @@ class PasswordlessInteractorSpec: QuickSpec {
                     waitUntil(timeout: 2) { done in
                         interactor.login(connection.name) { error in
                             expect(error) == .nonValidInput
+                            done()
+                        }
+                    }
+                }
+                
+                it("should indicate that a custom rule prevented the user from logging in") {
+                    stub(condition: databaseLogin(identifier: phone, password: code, connection: connection.name)) { _ in return Auth0Stubs.failure("unauthorized", description: "Only admins can use this") }
+                    try! interactor.update(.phone, value: phone)
+                    try! interactor.update(.oneTimePassword, value: code)
+                    waitUntil(timeout: 2) { done in
+                        interactor.login(connection.name) { error in
+                            expect(error) == .customRuleFailure(cause: "Only admins can use this")
                             done()
                         }
                     }


### PR DESCRIPTION
Auth0 Custom Rules functions allow an error to be returned with a custom message that provides context surrounding the error. For Example:
```
UnauthorizedError('Only admins can use this')
```
The current Lock error handling swallows this error message and returns it as a generic error:
>WE'RE SORRY, SOMETHING WENT WRONG WHEN ATTEMPTING TO LOG IN.

This pull request attempts to reduce some end user confusion surrounding generic errors by surfacing the provided error message to the user.

A new error case has been added which encapsulates any Custom Rule errors and associates the message provided so that it is surfaced to the user.

This brings parity with the Android SDK that does surface the error message to users and restores functionality previously available from #92 and #130.

Thanks