### PR TITLE
Release 2.3.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.3.1](https://github.com/auth0/Lock.swift/tree/2.3.1) (2017-07-11)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.3.0...2.3.1)
+
+**Added**
+- Added Error message on database user creation if user already exists [\#443](https://github.com/auth0/Lock.swift/pull/443) ([f2m2rd](https://github.com/f2m2rd))
+- Added allowShowPassword option, toggle password text visibility [\#442](https://github.com/auth0/Lock.swift/pull/442) ([cocojoe](https://github.com/cocojoe))
+
+**Changed**
+- Added Grant information for Passwordless docheaders [\#441](https://github.com/auth0/Lock.swift/pull/441) ([cocojoe](https://github.com/cocojoe))
+
 ## [2.3.0](https://github.com/auth0/Lock.swift/tree/2.3.0) (2017-06-06)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.2.0...2.3.0)
 **Closed issues**

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "AliSoftware/OHHTTPStubs" "6.0.0"
 github "Quick/Nimble" "v6.1.0"
 github "Quick/Quick" "v1.1.0"
-github "auth0/Auth0.swift" "1.7.0"
+github "auth0/Auth0.swift" "1.7.1"
 github "auth0/SimpleKeychain" "0.8.0"
 github "emaloney/CleanroomLogger" "5.1.1"

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
**Added**
- Added Error message on database user creation if user already exists [\#443](https://github.com/auth0/Lock.swift/pull/443) ([f2m2rd](https://github.com/f2m2rd))
- Added allowShowPassword option, toggle password text visibility [\#442](https://github.com/auth0/Lock.swift/pull/442) ([cocojoe](https://github.com/cocojoe))

**Changed**
- Added Grant information for Passwordless docheaders [\#441](https://github.com/auth0/Lock.swift/pull/441) ([cocojoe](https://github.com/cocojoe))