### PR TITLE
Improve support for custom fields during sign-up

### DIFF
--- a/Lock/DatabaseInteractor.swift
+++ b/Lock/DatabaseInteractor.swift
@@ -111,6 +111,10 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
             else { return callback(.nonValidInput, nil) }
 
         guard !connection.requiresUsername || self.validUsername else { return callback(.nonValidInput, nil) }
+        
+        for (fieldName, field) in customFields {
+            guard self.user.validAdditionaAttribute(fieldName) else { return callback(.nonValidInput, nil) }
+        }
 
         let username = connection.requiresUsername ? self.username : nil
         let metadata: [String: String]? = self.user.additionalAttributes.isEmpty ? nil : self.user.additionalAttributes

--- a/Lock/DatabaseOnlyView.swift
+++ b/Lock/DatabaseOnlyView.swift
@@ -132,12 +132,19 @@ class DatabaseOnlyView: UIView, DatabaseView {
         let form = SignUpView(additionalFields: additionalFields)
         form.showUsername = showUsername
         form.emailField.text = email
-        form.emailField.returnKey = .next
         form.emailField.nextField = showUsername ? form.usernameField : form.passwordField
         form.usernameField?.text = username
         form.usernameField?.returnKey = .next
         form.usernameField?.nextField = form.passwordField
-        form.passwordField.returnKey = .done
+        
+        if additionalFields.isEmpty == false {
+            form.passwordField.nextField = form.extraFields.first
+            
+            for i in form.extraFields.indices.dropLast() {
+                form.extraFields[i].nextField = form.extraFields[i+1]
+            }
+        }
+        
         primaryButton?.title = "SIGN UP".i18n(key: "com.auth0.lock.submit.signup.title", comment: "Signup Button title")
         layoutInStack(form, authCollectionView: authCollectionView)
         self.layoutSecondaryButton(true)

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -240,6 +240,12 @@ class DatabasePresenter: Presentable, Loggable {
             let tos = UIAlertAction(title: "Terms of Service".i18n(key: "com.auth0.lock.database.tos.sheet.title", comment: "ToS"), style: .default, handler: safariBuilder(forURL: self.options.termsOfServiceURL as URL, navigator: self.navigator))
             let privacy = UIAlertAction(title: "Privacy Policy".i18n(key: "com.auth0.lock.database.tos.sheet.privacy", comment: "Privacy"), style: .default, handler: safariBuilder(forURL: self.options.privacyPolicyURL as URL, navigator: self.navigator))
             [cancel, tos, privacy].forEach { alert.addAction($0) }
+            
+            // Provide location information (required for iPad)
+            alert.popoverPresentationController?.sourceView = button
+            alert.popoverPresentationController?.sourceRect = button.bounds
+            
+            alert.view.layoutIfNeeded()
             self.navigator.present(alert)
         }
 

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -190,7 +190,24 @@ class DatabasePresenter: Presentable, Loggable {
                         if !self.options.loginAfterSignup {
                             let message = "Thanks for signing up.".i18n(key: "com.auth0.lock.database.signup.success.message", comment: "User signed up")
                             if let databaseView = self.databaseView, self.options.allow.contains(.Login) {
+                                self.databaseView?.switcher?.segmentedControl?.selectedSegmentIndex = DatabaseModeSwitcher.Mode.login.rawValue
                                 self.showLogin(inView: databaseView, identifier: self.creator.identifier)
+                                
+                                // Clear the password for repeat sign-ups
+                                do {
+                                    try self.authenticator.update(.password(enforcePolicy: true), value: nil)
+                                } catch {
+                                    self.logger.error("could not clear the password field")
+                                }
+                                
+                                // Clear the custom field values for repeat sign-ups
+                                for customField in self.options.customSignupFields {
+                                    do {
+                                        try self.authenticator.update(.custom(name: customField.name), value: nil)
+                                    } catch {
+                                        self.logger.error("could not clear the custom field \(customField.name)")
+                                    }
+                                }
                             }
                             if self.options.allow.contains(.Login) || !self.options.autoClose {
                                 self.messagePresenter?.showSuccess(message)

--- a/Lock/SignUpView.swift
+++ b/Lock/SignUpView.swift
@@ -26,6 +26,7 @@ class SignUpView: UIView, Form {
     var emailField: InputField
     var passwordField: InputField
     var usernameField: InputField?
+    var extraFields: [InputField] = []
     var stackView: UIStackView
 
     var showUsername: Bool = false {
@@ -76,7 +77,8 @@ class SignUpView: UIView, Form {
         self.emailField = inputField(withType: .email)
         self.passwordField = inputField(withType: .password)
         var fields = [emailField, passwordField]
-        fields.append(contentsOf: additionalFields.map { return inputField(withType: $0.type) })
+        self.extraFields = additionalFields.map { return inputField(withType: $0.type) }
+        fields.append(contentsOf: self.extraFields)
         self.stackView = UIStackView(arrangedSubviews: fields)
         super.init(frame: CGRect.zero)
         self.layoutForm()


### PR DESCRIPTION
Changes:

- Perform validation for custom fields on sign-up

- Fix "next" button on custom fields

- Remove forced "done" button on password field

- Clear password value and custom field values after successful sign-up
  to prevent re-use of personal information for subsequent sign-ups by
  other users

- Show the correct selected segmented UI when showing the login form
  after signing-up
