### PR TITLE
Support iOS 11 safe area layout guides

### DIFF
--- a/Lock/DatabaseForgotPasswordView.swift
+++ b/Lock/DatabaseForgotPasswordView.swift
@@ -54,8 +54,14 @@ class DatabaseForgotPasswordView: UIView, View {
 
         constraintEqual(anchor: primaryButton.leftAnchor, toAnchor: self.leftAnchor)
         constraintEqual(anchor: primaryButton.rightAnchor, toAnchor: self.rightAnchor)
-        constraintEqual(anchor: primaryButton.bottomAnchor, toAnchor: self.bottomAnchor)
         primaryButton.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(iOS 11, *) {
+            let guide = self.safeAreaLayoutGuide
+            constraintEqual(anchor: primaryButton.bottomAnchor, toAnchor: guide.bottomAnchor)
+        } else {
+            constraintEqual(anchor: primaryButton.bottomAnchor, toAnchor: self.bottomAnchor)
+        }
 
         primaryButton.title = "SEND EMAIL".i18n(key: "com.auth0.lock.submit.send_email.title", comment: "Send Email button title")
         forgotView.type = .email

--- a/Lock/DatabaseOnlyView.swift
+++ b/Lock/DatabaseOnlyView.swift
@@ -76,8 +76,14 @@ class DatabaseOnlyView: UIView, DatabaseView {
 
         constraintEqual(anchor: primaryButton.leftAnchor, toAnchor: self.leftAnchor)
         constraintEqual(anchor: primaryButton.rightAnchor, toAnchor: self.rightAnchor)
-        constraintEqual(anchor: primaryButton.bottomAnchor, toAnchor: self.bottomAnchor)
         primaryButton.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(iOS 11, *) {
+            let guide = self.safeAreaLayoutGuide
+            constraintEqual(anchor: primaryButton.bottomAnchor, toAnchor: guide.bottomAnchor)
+        } else {
+            constraintEqual(anchor: primaryButton.bottomAnchor, toAnchor: self.bottomAnchor)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Lock/HeaderView.swift
+++ b/Lock/HeaderView.swift
@@ -139,7 +139,6 @@ public class HeaderView: UIView {
         constraintEqual(anchor: centerGuide.centerYAnchor, toAnchor: self.centerYAnchor, constant: 10)
         constraintEqual(anchor: centerGuide.centerXAnchor, toAnchor: self.centerXAnchor)
 
-        constraintEqual(anchor: titleView.bottomAnchor, toAnchor: centerGuide.bottomAnchor)
         constraintEqual(anchor: titleView.centerXAnchor, toAnchor: centerGuide.centerXAnchor)
         titleView.setContentCompressionResistancePriority(UILayoutPriority.priorityRequired, for: .horizontal)
         titleView.setContentHuggingPriority(UILayoutPriority.priorityRequired, for: .horizontal)
@@ -147,20 +146,32 @@ public class HeaderView: UIView {
 
         constraintEqual(anchor: logoView.centerXAnchor, toAnchor: self.centerXAnchor)
         constraintEqual(anchor: logoView.bottomAnchor, toAnchor: titleView.topAnchor, constant: -15)
-        constraintEqual(anchor: logoView.topAnchor, toAnchor: centerGuide.topAnchor)
         logoView.translatesAutoresizingMaskIntoConstraints = false
 
-        constraintEqual(anchor: closeButton.centerYAnchor, toAnchor: self.topAnchor, constant: 45)
-        constraintEqual(anchor: closeButton.rightAnchor, toAnchor: self.rightAnchor, constant: -10)
         closeButton.widthAnchor.constraint(equalToConstant: 25).isActive = true
         closeButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
         closeButton.translatesAutoresizingMaskIntoConstraints = false
 
-        constraintEqual(anchor: backButton.centerYAnchor, toAnchor: self.topAnchor, constant: 45)
-        constraintEqual(anchor: backButton.leftAnchor, toAnchor: self.leftAnchor, constant: 10)
         backButton.widthAnchor.constraint(equalToConstant: 25).isActive = true
         backButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
         backButton.translatesAutoresizingMaskIntoConstraints = false
+
+        if #available(iOS 11, *) {
+            let guide = self.safeAreaLayoutGuide
+            constraintEqual(anchor: titleView.bottomAnchor, toAnchor: guide.bottomAnchor, constant: -5)
+            constraintEqual(anchor: closeButton.centerYAnchor, toAnchor: guide.topAnchor, constant: 15)
+            constraintEqual(anchor: closeButton.rightAnchor, toAnchor: guide.rightAnchor, constant: -10)
+            constraintEqual(anchor: backButton.centerYAnchor, toAnchor: guide.topAnchor, constant: 15)
+            constraintEqual(anchor: backButton.leftAnchor, toAnchor: guide.leftAnchor, constant: 10)
+            constraintEqual(anchor: logoView.topAnchor, toAnchor: guide.topAnchor)
+        } else {
+            constraintEqual(anchor: titleView.bottomAnchor, toAnchor: centerGuide.bottomAnchor)
+            constraintEqual(anchor: closeButton.centerYAnchor, toAnchor: self.topAnchor, constant: 45)
+            constraintEqual(anchor: closeButton.rightAnchor, toAnchor: self.rightAnchor, constant: -10)
+            constraintEqual(anchor: backButton.centerYAnchor, toAnchor: self.topAnchor, constant: 45)
+            constraintEqual(anchor: backButton.leftAnchor, toAnchor: self.leftAnchor, constant: 10)
+            constraintEqual(anchor: logoView.topAnchor, toAnchor: centerGuide.topAnchor)
+        }
 
         self.applyBackground()
         self.apply(style: Style.Auth0)

--- a/Lock/HeaderView.swift
+++ b/Lock/HeaderView.swift
@@ -126,6 +126,7 @@ public class HeaderView: UIView {
     private func layoutHeader() {
         let titleView = UILabel()
         let logoView = UIImageView()
+        logoView.contentMode = .scaleAspectFit
         let closeButton = UIButton(type: .system)
         let backButton = UIButton(type: .system)
         let centerGuide = UILayoutGuide()
@@ -145,7 +146,7 @@ public class HeaderView: UIView {
         titleView.translatesAutoresizingMaskIntoConstraints = false
 
         constraintEqual(anchor: logoView.centerXAnchor, toAnchor: self.centerXAnchor)
-        constraintEqual(anchor: logoView.bottomAnchor, toAnchor: titleView.topAnchor, constant: -15)
+        constraintEqual(anchor: logoView.bottomAnchor, toAnchor: titleView.topAnchor, constant: 0)
         logoView.translatesAutoresizingMaskIntoConstraints = false
 
         closeButton.widthAnchor.constraint(equalToConstant: 25).isActive = true
@@ -158,7 +159,7 @@ public class HeaderView: UIView {
 
         if #available(iOS 11, *) {
             let guide = self.safeAreaLayoutGuide
-            constraintEqual(anchor: titleView.bottomAnchor, toAnchor: guide.bottomAnchor, constant: -5)
+            constraintEqual(anchor: titleView.bottomAnchor, toAnchor: guide.bottomAnchor, constant: -10)
             constraintEqual(anchor: closeButton.centerYAnchor, toAnchor: guide.topAnchor, constant: 15)
             constraintEqual(anchor: closeButton.rightAnchor, toAnchor: guide.rightAnchor, constant: -10)
             constraintEqual(anchor: backButton.centerYAnchor, toAnchor: guide.topAnchor, constant: 15)
@@ -192,7 +193,7 @@ public class HeaderView: UIView {
     }
 
     public override var intrinsicContentSize: CGSize {
-        return CGSize(width: 200, height: 154)
+        return CGSize(width: 200, height: 170)
     }
 
     @objc func buttonPressed(_ sender: UIButton) {


### PR DESCRIPTION
I've added safe area layout guide support on database only and database forgot password views to improve the UI display on iPhone X. If my changes are deemed acceptable, I can make additional changes for the enterprise views. Thanks for taking the time to take a look, and please let me know if you have any questions!