### PR TITLE
Release 2.7.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [2.7.0](https://github.com/auth0/Lock.swift/tree/2.7.0) (2018-09-18)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.6.0...2.7.0)
+
+**Added**
+- Added Password Complexity Support in Password Policies [\#513](https://github.com/auth0/Lock.swift/pull/513) ([cocojoe](https://github.com/cocojoe))
+
+**Changed**
+- Ensure Xcode10 Auth0.swift dependency used [\#516](https://github.com/auth0/Lock.swift/pull/516) ([cocojoe](https://github.com/cocojoe))
+
+**Deprecated**
+- Deprecated static vars in password policy in favour of funcs [\#514](https://github.com/auth0/Lock.swift/pull/514) ([cocojoe](https://github.com/cocojoe))
+
+**Fixed**
+- Xcode 10 Update [\#515](https://github.com/auth0/Lock.swift/pull/515) ([cocojoe](https://github.com/cocojoe))
+
 ## [2.6.0](https://github.com/auth0/Lock.swift/tree/2.6.0) (2018-06-12)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.5.1...2.6.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
  Add the following line to your Podfile:
 
  ```ruby
- pod "Lock", "~> 2.6"
+ pod "Lock", "~> 2.7"
  ```
 
 ### Carthage
@@ -39,7 +39,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
 In your `Cartfile` add
 
 ```ruby
-github "auth0/Lock.swift" ~> 2.6
+github "auth0/Lock.swift" ~> 2.7
 ```
 
 ## Usage


### PR DESCRIPTION
**Added**
- Added Password Complexity Support in Password Policies [\#513](https://github.com/auth0/Lock.swift/pull/513) ([cocojoe](https://github.com/cocojoe))

**Changed**
- Ensure Xcode10 Auth0.swift dependency used [\#516](https://github.com/auth0/Lock.swift/pull/516) ([cocojoe](https://github.com/cocojoe))

**Deprecated**
- Deprecated static vars in password policy in favour of funcs [\#514](https://github.com/auth0/Lock.swift/pull/514) ([cocojoe](https://github.com/cocojoe))

**Fixed**
- Xcode 10 Update [\#515](https://github.com/auth0/Lock.swift/pull/515) ([cocojoe](https://github.com/cocojoe))