### PR TITLE
[wip] Don't show the signup terms banner if there is no terms string

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -125,6 +125,18 @@ class ViewController: UIViewController {
                         connections.database(name: "Username-Password-Authentication", requiresUsername: true)
                 }
             },
+            actionButton(withTitle: "SIGNUP ONLY WITH DB") {
+                return Lock
+                    .classic()
+                    .withOptions {
+                        applyDefaultOptions(&$0)
+                        $0.allow = [.Signup]
+                        $0.usernameStyle = [.Email]
+                    }
+                    .withConnections { connections in
+                        connections.database(name: "Username-Password-Authentication", requiresUsername: true)
+                }
+            },
             actionButton(withTitle: "LOGIN WITH DB & SOCIAL") {
                 return Lock
                     .classic()

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -228,18 +228,20 @@ class DatabasePresenter: Presentable, Loggable {
             guard let button = view?.primaryButton, field.returnKey == .done else { return } // FIXME: Log warn
             checkTermsAndSignup(button)
         }
-        view.primaryButton?.onPress = checkTermsAndSignup
-        view.secondaryButton?.title = "By signing up, you agree to our terms of\n service and privacy policy".i18n(key: "com.auth0.lock.database.button.tos", comment: "tos & privacy")
-        view.secondaryButton?.color = UIColor ( red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0 )
-        view.secondaryButton?.onPress = { button in
-            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-            alert.popoverPresentationController?.sourceView = button
-            alert.popoverPresentationController?.sourceRect = button.bounds
-            let cancel = UIAlertAction(title: "Cancel".i18n(key: "com.auth0.lock.database.tos.sheet.cancel", comment: "Cancel"), style: .cancel, handler: nil)
-            let tos = UIAlertAction(title: "Terms of Service".i18n(key: "com.auth0.lock.database.tos.sheet.title", comment: "ToS"), style: .default, handler: safariBuilder(forURL: self.options.termsOfServiceURL as URL, navigator: self.navigator))
-            let privacy = UIAlertAction(title: "Privacy Policy".i18n(key: "com.auth0.lock.database.tos.sheet.privacy", comment: "Privacy"), style: .default, handler: safariBuilder(forURL: self.options.privacyPolicyURL as URL, navigator: self.navigator))
-            [cancel, tos, privacy].forEach { alert.addAction($0) }
-            self.navigator.present(alert)
+        if let terms = "By signing up, you agree to our terms of\n service and privacy policy".i18n(key: "com.auth0.lock.database.button.tos", comment: "tos & privacy") as String!, terms != "com.auth0.lock.database.button.tos" {
+            view.primaryButton?.onPress = checkTermsAndSignup
+            view.secondaryButton?.title = terms
+            view.secondaryButton?.color = UIColor ( red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0 )
+            view.secondaryButton?.onPress = { button in
+                let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                alert.popoverPresentationController?.sourceView = button
+                alert.popoverPresentationController?.sourceRect = button.bounds
+                let cancel = UIAlertAction(title: "Cancel".i18n(key: "com.auth0.lock.database.tos.sheet.cancel", comment: "Cancel"), style: .cancel, handler: nil)
+                let tos = UIAlertAction(title: "Terms of Service".i18n(key: "com.auth0.lock.database.tos.sheet.title", comment: "ToS"), style: .default, handler: safariBuilder(forURL: self.options.termsOfServiceURL as URL, navigator: self.navigator))
+                let privacy = UIAlertAction(title: "Privacy Policy".i18n(key: "com.auth0.lock.database.tos.sheet.privacy", comment: "Privacy"), style: .default, handler: safariBuilder(forURL: self.options.privacyPolicyURL as URL, navigator: self.navigator))
+                [cancel, tos, privacy].forEach { alert.addAction($0) }
+                self.navigator.present(alert)
+            }
         }
 
         if let identifyField = view.identityField, let passwordField = view.passwordField {

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -459,6 +459,11 @@ class DatabasePresenterSpec: QuickSpec {
                 view.switcher?.selected = .signup
                 view.switcher?.onSelectionChange(view.switcher!)
             }
+            
+            it("should not set title for secondary button when there is no tos string") {
+                //do something
+                expect(view.secondaryButton?.title).to(beNil())
+            }
 
             it("should set title for secondary button") {
                 expect(view.secondaryButton?.title).notTo(beNil())


### PR DESCRIPTION
We're making this change to make all Lock versions behave in the same way.

The idea here is that the Terms and Conditions banner will be always visible, unless the translated string `com.auth0.lock.database.button.tos` is empty.

To hide it, just set `com.auth0.lock.database.button.tos` to an empty string in the internationalization file.

Default:
![image](https://user-images.githubusercontent.com/941075/45823822-f08a2f80-bcc4-11e8-9d15-0c1781926c7d.png)

With an empty `com.auth0.lock.database.button.tos` string:
![image](https://user-images.githubusercontent.com/941075/45823861-08fa4a00-bcc5-11e8-95d6-db98902e1859.png)
