### PR TITLE
Fixed Authentication HTTP logging pass through flag 

### DIFF
--- a/Lock/Lock.swift
+++ b/Lock/Lock.swift
@@ -171,8 +171,8 @@ public class Lock: NSObject {
         closure(&builder)
         self.optionsBuilder = builder
         self.observerStore.options = self.options
-        _ = self.authentication.logging(enabled: self.options.logHttpRequest)
-        _ = self.webAuth.logging(enabled: self.options.logHttpRequest)
+        self.authentication = self.authentication.logging(enabled: self.options.logHttpRequest)
+        self.webAuth = self.webAuth.logging(enabled: self.options.logHttpRequest)
         return self
     }
 

--- a/LockTests/LockSpec.swift
+++ b/LockTests/LockSpec.swift
@@ -72,6 +72,14 @@ class LockSpec: QuickSpec {
             it("should return itself") {
                 expect(lock.withOptions { _ in } ) == lock
             }
+            
+            context("loggable") {
+                it("should enable logging") {
+                    _ = lock.withOptions { $0.logHttpRequest = true }
+                    expect(lock.authentication.logger).toNot(beNil())
+                    expect(lock.webAuth.logger).toNot(beNil())
+                }
+            }
         }
 
         describe("withConnections") {

--- a/LockTests/LockSpec.swift
+++ b/LockTests/LockSpec.swift
@@ -74,11 +74,18 @@ class LockSpec: QuickSpec {
             }
             
             context("loggable") {
+                
+                it("should be disabled by default") {
+                    expect(lock.authentication.logger).to(beNil())
+                    expect(lock.webAuth.logger).to(beNil())
+                }
+                
                 it("should enable logging") {
                     _ = lock.withOptions { $0.logHttpRequest = true }
                     expect(lock.authentication.logger).toNot(beNil())
                     expect(lock.webAuth.logger).toNot(beNil())
                 }
+                
             }
         }
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

The option `logHttpRequest` was not being processed correctly. This resulted
in not additional HTTP logs from the Auth0 authentication instances.

### References

Self discovered.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed