### PR TITLE
Release 2.9.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.0</string>
+	<string>2.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [2.9.0](https://github.com/auth0/Lock.swift/tree/2.9.0) (2018-12-12)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.8.0...2.9.0)
+
+**Added**
+- Update Dependencies [\#535](https://github.com/auth0/Lock.swift/pull/535) ([cocojoe](https://github.com/cocojoe))
+- Added Multiple Swift CI Support [\#530](https://github.com/auth0/Lock.swift/pull/530) ([cocojoe](https://github.com/cocojoe))
+- Added support for Swift 4.2 [\#529](https://github.com/auth0/Lock.swift/pull/529) ([guykogus](https://github.com/guykogus))
+- Added OIDC MFA Support [\#528](https://github.com/auth0/Lock.swift/pull/528) ([cocojoe](https://github.com/cocojoe))
+
+**Changed**
+- Fixed Authentication HTTP logging pass through flag  [\#527](https://github.com/auth0/Lock.swift/pull/527) ([cocojoe](https://github.com/cocojoe))
+
 ## [2.8.0](https://github.com/auth0/Lock.swift/tree/2.8.0) (2018-10-05)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.7.0...2.8.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.0</string>
+	<string>2.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.0</string>
+	<string>2.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.0</string>
+	<string>2.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
  Add the following line to your Podfile:
 
  ```ruby
- pod "Lock", "~> 2.8"
+ pod "Lock", "~> 2.9"
  ```
 
 ### Carthage
@@ -39,7 +39,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
 In your `Cartfile` add
 
 ```ruby
-github "auth0/Lock.swift" ~> 2.8
+github "auth0/Lock.swift" ~> 2.9
 ```
 
 ## Usage


### PR DESCRIPTION
**Added**
- Update Dependencies [\#535](https://github.com/auth0/Lock.swift/pull/535) ([cocojoe](https://github.com/cocojoe))
- Added Multiple Swift CI Support [\#530](https://github.com/auth0/Lock.swift/pull/530) ([cocojoe](https://github.com/cocojoe))
- Added support for Swift 4.2 [\#529](https://github.com/auth0/Lock.swift/pull/529) ([guykogus](https://github.com/guykogus))
- Added OIDC MFA Support [\#528](https://github.com/auth0/Lock.swift/pull/528) ([cocojoe](https://github.com/cocojoe))

**Changed**
- Fixed Authentication HTTP logging pass through flag  [\#527](https://github.com/auth0/Lock.swift/pull/527) ([cocojoe](https://github.com/cocojoe))