### PR TITLE
UITextContentType support in InputField

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -52,10 +52,6 @@ class ViewController: UIViewController {
                         applyDefaultOptions(&$0)
                         $0.passwordManager.appIdentifier = "www.myapp.com"
                         $0.passwordManager.displayName = "My App"
-                        $0.customSignupFields = [
-                            CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle)),
-                            CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle))
-                        ]
                         $0.enterpriseConnectionUsingActiveAuth = ["testAD"]
                     }
                     .withStyle {
@@ -78,10 +74,6 @@ class ViewController: UIViewController {
                     .classic()
                     .withOptions {
                         applyDefaultOptions(&$0)
-                        $0.customSignupFields = [
-                            CustomTextField(name: "first_name", placeholder: "First Name"),
-                            CustomTextField(name: "last_name", placeholder: "Last Name")
-                        ]
                         $0.enterpriseConnectionUsingActiveAuth = ["testAD"]
                     }
                     .withStyle {
@@ -103,10 +95,6 @@ class ViewController: UIViewController {
                     .passwordless()
                     .withOptions {
                         applyDefaultOptions(&$0)
-                        $0.customSignupFields = [
-                            CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle)),
-                            CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle)),
-                        ]
                     }
                     .withConnections { connections in
                         let usernameValidator = UsernameValidator(withLength: 1...20, characterSet: UsernameValidator.auth0)
@@ -212,6 +200,18 @@ func applyDefaultOptions(_ options: inout OptionBuildable) {
     options.loggerOutput = CleanroomLockLogger()
     options.logHttpRequest = true
     options.oidcConformant = true
+
+    if #available(iOS 10, *) {
+        options.customSignupFields = [
+            CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .givenName),
+            CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .familyName)
+        ]
+    } else {
+        options.customSignupFields = [
+            CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle)),
+            CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle))
+        ]
+    }
 }
 
 func applyPhantomStyle(_ style: inout Style) {

--- a/Lock/CustomTextField.swift
+++ b/Lock/CustomTextField.swift
@@ -30,20 +30,22 @@ public struct CustomTextField {
     let keyboardType: UIKeyboardType
     let autocorrectionType: UITextAutocorrectionType
     let secure: Bool
+    let contentType: UITextContentType?
     let validation: (String?) -> Error?
 
-    public init(name: String, placeholder: String, icon: LazyImage? = nil, keyboardType: UIKeyboardType = .default, autocorrectionType: UITextAutocorrectionType = .default, secure: Bool = false, validation: @escaping (String?) -> Error? = nonEmpty) {
+    public init(name: String, placeholder: String, icon: LazyImage? = nil, keyboardType: UIKeyboardType = .default, autocorrectionType: UITextAutocorrectionType = .default, secure: Bool = false, contentType: UITextContentType? = nil, validation: @escaping (String?) -> Error? = nonEmpty) {
         self.name = name
         self.placeholder = placeholder
         self.icon = icon
         self.keyboardType = keyboardType
         self.autocorrectionType = autocorrectionType
         self.secure = secure
+        self.contentType = contentType
         self.validation = validation
     }
 
     var type: InputField.InputType {
-        return .custom(name: name, placeholder: placeholder, icon: icon, keyboardType: keyboardType, autocorrectionType: self.autocorrectionType, secure: secure)
+        return .custom(name: name, placeholder: placeholder, icon: icon, keyboardType: keyboardType, autocorrectionType: self.autocorrectionType, secure: secure, contentType: contentType)
     }
 }
 

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -286,7 +286,7 @@ class DatabasePresenter: Presentable, Loggable {
             attribute = .password(enforcePolicy: self.currentScreen == .signup)
         case .username:
             attribute = .username
-        case .custom(let name, _, _, _, _, _):
+        case .custom(let name, _, _, _, _, _, _):
             attribute = .custom(name: name)
         default:
             return

--- a/LockTests/InputFieldSpec.swift
+++ b/LockTests/InputFieldSpec.swift
@@ -80,5 +80,112 @@ class InputFieldSpec: QuickSpec {
             }
             
         }
+
+        describe("keyboard type") {
+            var input: InputField!
+            var text: UITextField!
+
+            beforeEach {
+                input = InputField()
+                text = input.textField
+            }
+
+            it("should assign email type") {
+                input.type = .email
+                expect(text.keyboardType) == UIKeyboardType.emailAddress
+            }
+
+            it("should assign username type") {
+                input.type = .username
+                expect(text.keyboardType) == UIKeyboardType.default
+            }
+
+            it("should assign emailOrUsername type") {
+                input.type = .emailOrUsername
+                expect(text.keyboardType) == UIKeyboardType.emailAddress
+            }
+
+            it("should assign password type") {
+                input.type = .password
+                expect(text.keyboardType) == UIKeyboardType.default
+            }
+
+
+            it("should assign phone type") {
+                input.type = .phone
+                expect(text.keyboardType) == UIKeyboardType.phonePad
+            }
+
+            it("should assign oneTimePassword type") {
+                input.type = .oneTimePassword
+                expect(text.keyboardType) == UIKeyboardType.decimalPad
+            }
+
+            it("should assign custom type") {
+                input.type = .custom(name: "test", placeholder: "", icon: nil, keyboardType: .twitter, autocorrectionType: .no, secure: false, contentType: nil)
+                expect(text.keyboardType) == UIKeyboardType.twitter
+            }
+        }
+
+        describe("content type") {
+            var input: InputField!
+            var text: UITextField!
+
+            beforeEach {
+                input = InputField()
+                text = input.textField
+            }
+
+            if #available(iOS 10.0, *) {
+                it("should assign email type") {
+                    input.type = .email
+                    expect(text.textContentType) == UITextContentType.emailAddress
+                }
+            }
+
+            if #available(iOS 11.0, *) {
+                it("should assign username type") {
+                    input.type = .username
+                    expect(text.textContentType) == UITextContentType.username
+                }
+            }
+
+            if #available(iOS 10.0, *) {
+                it("should assign emailOrUsername type") {
+                    input.type = .emailOrUsername
+                    expect(text.textContentType) == UITextContentType.emailAddress
+                }
+            }
+
+            if #available(iOS 11.0, *) {
+                it("should assign password type") {
+                    input.type = .password
+                    expect(text.textContentType) == UITextContentType.password
+                }
+            }
+
+            if #available(iOS 10.0, *) {
+                it("should assign phone type") {
+                    input.type = .phone
+                    expect(text.textContentType) == UITextContentType.telephoneNumber
+                }
+            }
+
+            #if swift(>=4.0)
+                if #available(iOS 12.0, *) {
+                    it("should assign oneTimePassword type") {
+                        input.type = .oneTimePassword
+                        expect(text.textContentType) == UITextContentType.oneTimeCode
+                    }
+                }
+            #endif
+
+            if #available(iOS 10.0, *) {
+                it("should assign custom type") {
+                    input.type = .custom(name: "test", placeholder: "", icon: nil, keyboardType: .default, autocorrectionType: .no, secure: false, contentType: .name)
+                    expect(text.textContentType) == UITextContentType.name
+                }
+            }
+        }
     }
 }

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -529,7 +529,7 @@ class DatabasePresenterSpec: QuickSpec {
 
                 it("should custom field") {
                     let name = "Auth0"
-                    let input = mockInput(.custom(name: "first_name", placeholder: "Name", icon: LazyImage(name: "ic_auth0", bundle: Lock.bundle), keyboardType: .default, autocorrectionType: .no, secure: false), value: name)
+                    let input = mockInput(.custom(name: "first_name", placeholder: "Name", icon: LazyImage(name: "ic_auth0", bundle: Lock.bundle), keyboardType: .default, autocorrectionType: .no, secure: false, contentType: nil), value: name)
                     view.form?.onValueChange(input)
                     expect(interactor.custom["first_name"]) == name
                 }

--- a/README.md
+++ b/README.md
@@ -420,8 +420,8 @@ When signing up the default information requirements are the user's *email* and 
 ```swift
 .withOptions {
   $0.customSignupFields = [
-    CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle)),
-    CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle))
+    CustomTextField(name: "first_name", placeholder: "First Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .givenName),
+    CustomTextField(name: "last_name", placeholder: "Last Name", icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .familyName)
   ]
 }
 ```


### PR DESCRIPTION
### Changes

Assigns the appropriate `UITextContentType` based on `InputField.InputType`.
Assigning the content type of the text field allows iOS to better match auto-fill values.

#### Public API Changes
- An optional `contentType: UITextContentType?` argument was added to `CustomTextField.init`

#### Before and After
![before](https://user-images.githubusercontent.com/915431/55030462-a95d5e00-4fc9-11e9-91c4-7fcdfb3cdb93.png) ![after](https://user-images.githubusercontent.com/915431/55030461-a95d5e00-4fc9-11e9-84a7-bbd680cfceda.png)

### References

- [`UITextInputTraits.textContentType`](https://developer.apple.com/documentation/uikit/uitextinputtraits/1649656-textcontenttype)
- [`UITextContentType`](https://developer.apple.com/documentation/uikit/uitextcontenttype)
- [Enabling Password AutoFill on a Text Input View](https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_a_text_input_view)
- [Automatic Strong Passwords and Security Code AutoFill](https://developer.apple.com/videos/play/wwdc2018/204/)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed