### PR TITLE
Release 2.10.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.10.0](https://github.com/auth0/Lock.swift/tree/2.10.0) (2019-04-25)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.9.0...2.10.0)
+
+**Added**
+- Added Swift 5 / Xcode 10.2 support [\#545](https://github.com/auth0/Lock.swift/pull/545) ([cocojoe](https://github.com/cocojoe))
+- UITextContentType support in InputField [\#542](https://github.com/auth0/Lock.swift/pull/542) ([ejensen](https://github.com/ejensen))
+
+**Changed**
+- Facebook compliance logo update [\#546](https://github.com/auth0/Lock.swift/pull/546) ([cocojoe](https://github.com/cocojoe))
+
 ## [2.9.0](https://github.com/auth0/Lock.swift/tree/2.9.0) (2018-12-12)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.8.0...2.9.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.0</string>
+	<string>2.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
  Add the following line to your Podfile:
 
  ```ruby
- pod "Lock", "~> 2.9"
+ pod "Lock", "~> 2.10"
  ```
 
 ### Carthage
@@ -39,7 +39,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
 In your `Cartfile` add
 
 ```ruby
-github "auth0/Lock.swift" ~> 2.9
+github "auth0/Lock.swift" ~> 2.10
 ```
 
 ## Usage


### PR DESCRIPTION
**Added**
- Added Swift 5 / Xcode 10.2 support [\#545](https://github.com/auth0/Lock.swift/pull/545) ([cocojoe](https://github.com/cocojoe))
- UITextContentType support in InputField [\#542](https://github.com/auth0/Lock.swift/pull/542) ([ejensen](https://github.com/ejensen))

**Changed**
- Facebook compliance logo update [\#546](https://github.com/auth0/Lock.swift/pull/546) ([cocojoe](https://github.com/cocojoe))