### PR TITLE
Update Email validation to allow uppercase characters

### DIFF
--- a/Lock/Validators.swift
+++ b/Lock/Validators.swift
@@ -102,7 +102,7 @@ public class EmailValidator: InputValidator {
     let predicate: NSPredicate
 
     public init() {
-        let regex = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+        let regex = "[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
         self.predicate = NSPredicate(format: "SELF MATCHES %@", regex)
     }
 

--- a/LockTests/EmailValidatorSpec.swift
+++ b/LockTests/EmailValidatorSpec.swift
@@ -37,7 +37,7 @@ class EmailValidatorSpec: QuickSpec {
             }
         }
 
-        ["test@iana.org", "test@nominet.org.uk", "test@about.museum", "a@iana.org", "test@e.com", "test@iana.a", "123@iana.org", "test@123.com", "test.mail@server.co.uk"].forEach { value in
+        ["test@iana.org", "test@nominet.org.uk", "test@about.museum", "a@iana.org", "test@e.com", "test@iana.a", "123@iana.org", "test@123.com", "test.mail@server.co.uk","TestEmail@server.com"].forEach { value in
             it("should consider \(value!) a valid email") {
                 expect(validator.validate(value)).to(beNil())
             }


### PR DESCRIPTION
Update tests

### Changes

Allow uppercase characters in Email e.g. `Test.Email@host.com`

### References

Internal

### Testing

Updated

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed