### PR TITLE
Release 2.10.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.10.0</string>
+	<string>2.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [2.10.1](https://github.com/auth0/Lock.swift/tree/2.10.1) (2019-05-07)
+From this release on, the option to display social connections in small styled buttons is no longer available due to branding compliance reasons. All the social connections will now be displayed as large styled buttons.
+
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.10.0...2.10.1)
+
+**Changed**
+- Update Email validation to allow uppercase characters [\#551](https://github.com/auth0/Lock.swift/pull/551) ([cocojoe](https://github.com/cocojoe))
+- Changed OAuth Google logo inline with new compliance [\#548](https://github.com/auth0/Lock.swift/pull/548) ([cocojoe](https://github.com/cocojoe))
+
 ## [2.10.0](https://github.com/auth0/Lock.swift/tree/2.10.0) (2019-04-25)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.9.0...2.10.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.10.0</string>
+	<string>2.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.10.0</string>
+	<string>2.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.10.0</string>
+	<string>2.10.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
From this release on, the option to display social connections in small styled buttons is no longer available due to branding compliance reasons. All the social connections will now be displayed as large styled buttons.

**Changed**
- Update Email validation to allow uppercase characters [\#551](https://github.com/auth0/Lock.swift/pull/551) ([cocojoe](https://github.com/cocojoe))
- Changed OAuth Google logo inline with new compliance [\#548](https://github.com/auth0/Lock.swift/pull/548) ([cocojoe](https://github.com/cocojoe))