### PR TITLE
Fix secondary button color after switching tabs

### DIFF
--- a/Lock/DatabaseOnlyView.swift
+++ b/Lock/DatabaseOnlyView.swift
@@ -111,8 +111,8 @@ class DatabaseOnlyView: UIView, DatabaseView {
         form.identityField.nextField = form.passwordField
         form.passwordField.returnKey = .done
         primaryButton?.title = "LOG IN".i18n(key: "com.auth0.lock.submit.login.title", comment: "Login Button title")
-        layoutInStack(form, authCollectionView: authCollectionView)
         self.layoutSecondaryButton(self.allowedModes.contains(.ResetPassword))
+        layoutInStack(form, authCollectionView: authCollectionView)
         self.form = form
         self.identityField = form.identityField
         self.passwordField = form.passwordField


### PR DESCRIPTION
Otherwise the secondary button "Don't remember your password?" will have
wrong color when you have custom secondaryButtonColor set and you switch
to "Sign Up" tab and back to "Log In" tab.

`self.layoutSecondaryButton()` must be called before `layoutInStack()` in `showLogin()`, because `layoutInStack` calls `styleSubViews()`.
`layoutSecondaryButton()` re-creates the `SecondaryButton` and when it is called after `layoutInStack()` the style is lost.

Maybe a more clear code would be extracting the styling part from `layoutInStack()` and calling the extracted styling after `layoutSecondaryButton()` and `layoutInStack()` in whatever order.

The same problem might be present in `showSignUp()` as well, where the order is the same. I have not investigated it further. The style of "agree to our terms" footnote looks ok in our app.