### PR TITLE
Fixed use default .fullScreen modalPresentationStyle

### DIFF
--- a/Lock/LockViewController.swift
+++ b/Lock/LockViewController.swift
@@ -41,9 +41,11 @@ public class LockViewController: UIViewController {
         self.lock = lock
         super.init(nibName: nil, bundle: nil)
         lock.observerStore.controller = self
-        if self.lock.style.modalPopup {
+        if self.lock.style.modalPopup && UIDevice.current.userInterfaceIdiom == .pad {
             self.modalPresentationStyle = .formSheet
             self.preferredContentSize = CGSize(width: 375, height: 667)
+        } else {
+            self.modalPresentationStyle = .fullScreen
         }
         self.router = lock.classicMode ? ClassicRouter(lock: lock, controller: self) : PasswordlessRouter(lock: lock, controller: self)
     }


### PR DESCRIPTION
### Changes

Default modalPresentationStyle has been changed to `.fullScreen` for iPhone. As no value was specified the default <iOS 13 was `.fullScreen`. Now it's automatic which presents in such a way that allows for Lock to be dismissed by the user.

[UIModalPresentationStyle Docs](https://developer.apple.com/documentation/uikit/uimodalpresentationstyle)

### References

#558 

### Testing

**Before**

![Simulator Screen Shot - iPhone 8 - 2019-07-18 at 12 42 24](https://user-images.githubusercontent.com/928115/61454697-84ff0600-a959-11e9-98ac-cc55d83c777e.png)

**After**

![Simulator Screen Shot - iPhone 8 - 2019-07-18 at 12 41 46](https://user-images.githubusercontent.com/928115/61454683-744e9000-a959-11e9-8772-9cb146b8b063.png)

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed