### PR TITLE
Options to pass-through custom user metadata

### DIFF
--- a/Lock/DatabaseInteractor.swift
+++ b/Lock/DatabaseInteractor.swift
@@ -121,8 +121,14 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
         }
 
         let username = connection.requiresUsername ? self.username : nil
-        let metadata: [String: String]? = self.user.additionalAttributes.isEmpty ? nil : self.user.additionalAttributes
         let rootAttributes: [String: String]? = self.user.rootAttributes.isEmpty ? nil : self.user.rootAttributes
+        let metadata: [String: String]?
+
+        if user.additionalAttributes.isEmpty && options.customSignupUserMetadata.isEmpty {
+            metadata = nil
+        } else {
+            metadata = user.additionalAttributes.merging(options.customSignupUserMetadata) { key, _ in key }
+        }
 
         let login = self.credentialAuth.request(withIdentifier: email, password: password, options: self.options)
         self.credentialAuth

--- a/Lock/LockOptions.swift
+++ b/Lock/LockOptions.swift
@@ -41,6 +41,7 @@ struct LockOptions: OptionBuildable {
     var initialScreen: DatabaseScreen = .login
     var usernameStyle: DatabaseIdentifierStyle = [.Username, .Email]
     var customSignupFields: [CustomTextField] = []
+    var customSignupUserMetadata: [String: String] = [:]
     var loginAfterSignup: Bool = true
 
     var activeDirectoryEmailAsUsername: Bool = false

--- a/Lock/OptionBuildable.swift
+++ b/Lock/OptionBuildable.swift
@@ -82,6 +82,9 @@ public protocol OptionBuildable: Options {
         /// Additional fields showed for Database Sign Up. By default the list is empty
     var customSignupFields: [CustomTextField] { get set }
 
+        /// Additional user metadata for Database Sign Up. By default the dictionary is empty
+    var customSignupUserMetadata: [String: String] { get set }
+
         /// Automatically log user in after sign up.  By default true
     var loginAfterSignup: Bool { get set }
 

--- a/Lock/Options.swift
+++ b/Lock/Options.swift
@@ -43,6 +43,7 @@ public protocol Options {
     var initialScreen: DatabaseScreen { get }
     var usernameStyle: DatabaseIdentifierStyle { get }
     var customSignupFields: [CustomTextField] { get }
+    var customSignupUserMetadata: [String: String] { get }
     var loginAfterSignup: Bool { get }
 
     var activeDirectoryEmailAsUsername: Bool { get }

--- a/LockTests/OptionsSpec.swift
+++ b/LockTests/OptionsSpec.swift
@@ -89,6 +89,10 @@ class OptionsSpec: QuickSpec {
                 expect(options.customSignupFields).to(beEmpty())
             }
 
+            it("should have no custom user metadata") {
+                expect(options.customSignupUserMetadata).to(beEmpty())
+            }
+
             it("should not be OIDC conformant") {
                 expect(options.oidcConformant) == false
             }
@@ -259,6 +263,11 @@ class OptionsSpec: QuickSpec {
             it("should ignore invalid support site") {
                 options.supportPage = "not a url"
                 expect(options.supportURL?.absoluteString).to(beNil())
+            }
+
+            it("should set customSignupUserMetadata") {
+                options.customSignupUserMetadata = ["key": "value"]
+                expect(options.customSignupUserMetadata["key"]) == "value"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -430,6 +430,19 @@ If you want to save the value of the attribute in the root of a user's profile, 
 
 *Note: You must specify the icon to use with your custom text field and store it in your App's bundle.*
 
+#### Custom Signup User Metadata
+
+When signing up, your app may need to assign values to the `user_metadata` object that are not entered by the user through [Custom Signup Fields](#custom-signup-fields).
+The `customSignupUserMetadata` option allows your app to assign specific values to the `user_metadata` object upon user account creation.
+
+```swift
+.withOptions {
+  $0.customSignupUserMetadata = [
+    "referral_code": referralCode
+  ]
+}
+```
+
 #### Password Manager
 
 This functionality has been removed as of Release 2.18 due to the 1Password extension using deprecated methods, which can result in your app being rejected by the AppStore. This functionality was superseded in iOS 12 when Apple introduced the integration of password managers into login forms.


### PR DESCRIPTION
### Changes

This adds the option to pass-through custom user metadata to the [`createUser`](https://auth0.com/docs/libraries/auth0-swift/database-authentication#signing-up-with-a-database-connection) function on signup. This enables apps to assign values to the new user that should not be displayed as user-editable `CustomTextField`s

- Adds `customSignupUserMetadata` properties on the Lock Options type.
- Passes the `customSignupUserMetadata` value to the call to the Auth0 SDK's [`createUser`](https://auth0.com/docs/libraries/auth0-swift/database-authentication) method.

### References

- [Set Metadata Properties on Creation](https://auth0.com/docs/users/guides/set-metadata-properties-on-creation)
- Auth0 SDK's [`createUser` documentation](https://auth0.com/docs/libraries/auth0-swift/database-authentication#signing-up-with-a-database-connection)


### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed