### PR TITLE
Fix LockViewController scrolling

### DIFF
--- a/Lock/LockViewController.swift
+++ b/Lock/LockViewController.swift
@@ -27,6 +27,7 @@ public class LockViewController: UIViewController {
     weak var headerView: HeaderView!
     weak var scrollView: UIScrollView!
     weak var messageView: MessageView?
+    weak var scrollContentView: UIView!
     var current: View?
     var keyboard: Bool = false
     var routes: Routes = Routes()
@@ -80,6 +81,9 @@ public class LockViewController: UIViewController {
         let scrollView = UIScrollView()
         scrollView.bounces = false
         scrollView.keyboardDismissMode = .interactive
+        if #available(iOS 11.0, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        }
         self.view.addSubview(scrollView)
         constraintEqual(anchor: scrollView.leftAnchor, toAnchor: self.view.leftAnchor)
         constraintEqual(anchor: scrollView.topAnchor, toAnchor: self.view.topAnchor)
@@ -88,12 +92,22 @@ public class LockViewController: UIViewController {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         self.scrollView = scrollView
 
+        let scrollContentView = UIView()
+        self.scrollView.addSubview(scrollContentView)
+        constraintEqual(anchor: scrollContentView.leftAnchor, toAnchor: scrollView.leftAnchor)
+        constraintEqual(anchor: scrollContentView.topAnchor, toAnchor: scrollView.topAnchor)
+        constraintEqual(anchor: scrollContentView.rightAnchor, toAnchor: scrollView.rightAnchor)
+        constraintEqual(anchor: scrollContentView.bottomAnchor, toAnchor: scrollView.bottomAnchor)
+        constraintEqual(anchor: scrollContentView.widthAnchor, toAnchor: scrollView.widthAnchor)
+        constraintEqual(anchor: scrollContentView.heightAnchor, toAnchor: view.heightAnchor, priority: .defaultLow)
+        scrollContentView.translatesAutoresizingMaskIntoConstraints = false
+        self.scrollContentView = scrollContentView
+
         let header = HeaderView()
-        self.scrollView.addSubview(header)
-        constraintEqual(anchor: header.leftAnchor, toAnchor: scrollView.leftAnchor)
-        constraintEqual(anchor: header.topAnchor, toAnchor: scrollView.topAnchor)
-        constraintEqual(anchor: header.rightAnchor, toAnchor: scrollView.rightAnchor)
-        constraintEqual(anchor: header.widthAnchor, toAnchor: scrollView.widthAnchor)
+        self.scrollContentView.addSubview(header)
+        constraintEqual(anchor: header.leftAnchor, toAnchor: scrollContentView.leftAnchor)
+        constraintEqual(anchor: header.topAnchor, toAnchor: scrollContentView.topAnchor)
+        constraintEqual(anchor: header.rightAnchor, toAnchor: scrollContentView.rightAnchor)
         header.translatesAutoresizingMaskIntoConstraints = false
 
         header.showClose = self.lock.options.closable
@@ -128,7 +142,7 @@ public class LockViewController: UIViewController {
         self.current?.remove()
         let view = presenter.view
         view.applyAll(withStyle: self.lock.style)
-        self.anchorConstraint = view.layout(inView: self.scrollView, below: self.headerView)
+        self.anchorConstraint = view.layout(inView: self.scrollContentView, below: self.headerView)
         presenter.messagePresenter = self.messagePresenter
         self.current = view
         self.headerView.title = title


### PR DESCRIPTION
### Changes

Fixes scrolling within the `LockViewController` by adding Autolayout constraints that properly constrain the scrollview's content size.

*Before & After*
![before](https://user-images.githubusercontent.com/915431/64821811-7b180e80-d568-11e9-9025-ff5a1f1d8866.gif) ![after](https://user-images.githubusercontent.com/915431/64821252-3cce1f80-d567-11e9-9202-b2c475d398ae.gif)

### References
- [Technical Note TN2154 UIScrollView And Autolayout](https://developer.apple.com/library/archive/technotes/tn2154/_index.html)

### Testing

Tested on both iPhone and iPad simulators. iPhone recordings shown above

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed