### PR TITLE
Fix iOS 13.x Bug - Calling UI on non-main thread

### DIFF
--- a/Lock/ObserverStore.swift
+++ b/Lock/ObserverStore.swift
@@ -69,10 +69,9 @@ struct ObserverStore: Dispatcher {
         Queue.main.async(closure)
     }
 
-    private func dismiss(from sub: UIViewController?, completion: @escaping () -> Void) -> () -> Void {
+    private func dismiss(from controller: UIViewController?, completion: @escaping () -> Void) -> () -> Void {
 		return {
-			//controller?.presentingViewController has to be INSIDE Queue.main.async
-			if let controller = sub?.presentingViewController {
+			if let controller = controller?.presentingViewController {
 				controller.dismiss(animated: true, completion: completion)
 			} else {
 				completion()


### PR DESCRIPTION
### Changes

basically, controller.presentingViewController was being called/evaluated from non-main thread.
in iOS 13.1.x, they REALLY don’t like that - even if it’s just “inspection”

my app was rejected because the login view wasn’t being dismissed 

this PR fixes that - basically just moves the evaluation down into the actual _execution_ of the `Queue.main` without loss of functionality

Fixes #565 