### PR TITLE
Release 2.13.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.13.0</string>
+	<string>2.13.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.13.1](https://github.com/auth0/Lock.swift/tree/2.13.1) (2019-10-14)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.13.0...2.13.1)
+
+**Fixed**
+- Fix iOS 13.x Bug - Calling UI on non-main thread [\#576](https://github.com/auth0/Lock.swift/pull/576) ([pixeled](https://github.com/pixeled))
+
 ## [2.13.0](https://github.com/auth0/Lock.swift/tree/2.13.0) (2019-09-30)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.12.0...2.13.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.13.0</string>
+	<string>2.13.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.13.0</string>
+	<string>2.13.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.13.0</string>
+	<string>2.13.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
**Fixed**
- Fix iOS 13.x Bug - Calling UI on non-main thread [\#576](https://github.com/auth0/Lock.swift/pull/576) ([pixeled](https://github.com/pixeled))