### PR TITLE
Fix PrimaryButton chevron tinting

### DIFF
--- a/Lock/PrimaryButton.swift
+++ b/Lock/PrimaryButton.swift
@@ -120,15 +120,14 @@ class PrimaryButton: UIView, Stylable {
         attachment.image = image(named: "ic_chevron_right", compatibleWithTraitCollection: self.traitCollection)
         attachment.bounds = CGRect(x: 0.0, y: font.descender / 2.0, width: attachment.image!.size.width, height: attachment.image!.size.height)
 
-        let attributedText = NSMutableAttributedString()
-        attributedText.append(NSAttributedString(
-            string: "\(title)  ",
-            attributes: [
+        let attributedText = NSMutableAttributedString(string: "\(title)  ")
+        attributedText.append(NSAttributedString(attachment: attachment))
+        attributedText.addAttributes(
+            [
                 NSAttributedString.attributedKeyColor: self.textColor ?? Style.Auth0.buttonTintColor,
                 NSAttributedString.attributedFont: font
-            ]
-        ))
-        attributedText.append(NSAttributedString(attachment: attachment))
+            ],
+            range: NSRange(location: 0, length: attributedText.length))
         button.setAttributedTitle(attributedText, for: .normal)
         button.setAttributedTitle(NSAttributedString(), for: .disabled)
     }


### PR DESCRIPTION
### Changes

Applies the text attributes to the entire primary button string. This fixes the issue that the chevron image is not correctly tinted.

### References

- [NSMutableAttributedString](https://developer.apple.com/documentation/foundation/nsmutableattributedstring) 

### Testing

Before & After screenshot:
![before   after](https://user-images.githubusercontent.com/915431/67447825-02c25580-f5ca-11e9-9a09-29fffdd9538a.jpg)

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed