### PR TITLE
Added hidden CustomTextField support

### DIFF
--- a/Lock/CustomTextField.swift
+++ b/Lock/CustomTextField.swift
@@ -26,28 +26,34 @@ public struct CustomTextField {
 
     let name: String
     let placeholder: String
+    let defaultValue: String?
     let storage: UserStorage
     let icon: LazyImage?
     let keyboardType: UIKeyboardType
     let autocorrectionType: UITextAutocorrectionType
+    let autocapitalizationType: UITextAutocapitalizationType
     let secure: Bool
+    let hidden: Bool
     let contentType: UITextContentType?
     let validation: (String?) -> Error?
 
-    public init(name: String, placeholder: String, storage: UserStorage = .userMetadata, icon: LazyImage? = nil, keyboardType: UIKeyboardType = .default, autocorrectionType: UITextAutocorrectionType = .default, secure: Bool = false, contentType: UITextContentType? = nil, validation: @escaping (String?) -> Error? = nonEmpty) {
+    public init(name: String, placeholder: String, defaultValue: String? = nil, storage: UserStorage = .userMetadata, icon: LazyImage? = nil, keyboardType: UIKeyboardType = .default, autocorrectionType: UITextAutocorrectionType = .default, autocapitalizationType: UITextAutocapitalizationType = .none, secure: Bool = false, hidden: Bool = false, contentType: UITextContentType? = nil, validation: @escaping (String?) -> Error? = nonEmpty) {
         self.name = name
         self.placeholder = placeholder
+        self.defaultValue = defaultValue
         self.icon = icon
         self.keyboardType = keyboardType
         self.autocorrectionType = autocorrectionType
+        self.autocapitalizationType = autocapitalizationType
         self.secure = secure
+        self.hidden = hidden
         self.contentType = contentType
         self.validation = validation
         self.storage = storage
     }
 
     var type: InputField.InputType {
-        return .custom(name: name, placeholder: placeholder, storage: storage, icon: icon, keyboardType: keyboardType, autocorrectionType: self.autocorrectionType, secure: secure, contentType: contentType)
+        return .custom(name: name, placeholder: placeholder, defaultValue: defaultValue, storage: storage, icon: icon, keyboardType: keyboardType, autocorrectionType: autocorrectionType, autocapitalizationType: autocapitalizationType, secure: secure, hidden: hidden, contentType: contentType)
     }
 }
 

--- a/Lock/DatabaseOnlyView.swift
+++ b/Lock/DatabaseOnlyView.swift
@@ -141,7 +141,7 @@ class DatabaseOnlyView: UIView, DatabaseView {
 
         self.identityField = showUsername ? form.usernameField : form.emailField
         self.passwordField = form.passwordField
-        self.allFields = form.stackView.arrangedSubviews.map { $0 as? InputField }.filter { $0 != nil }.map { $0! }
+        self.allFields = form.stackView.arrangedSubviews.compactMap { $0 as? InputField }
 
         if let passwordPolicyValidator = passwordPolicyValidator {
             let passwordPolicyView = PolicyView(rules: passwordPolicyValidator.policy.rules)

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -249,7 +249,7 @@ class DatabasePresenter: Presentable, Loggable {
             attribute = .password(enforcePolicy: self.currentScreen == .signup)
         case .username:
             attribute = .username
-        case .custom(let name, _, let storage, _, _, _, _, _):
+        case .custom(let name, _, _, let storage, _, _, _, _, _, _, _):
             attribute = .custom(name: name, storage: storage)
         default:
             return

--- a/Lock/SignUpView.swift
+++ b/Lock/SignUpView.swift
@@ -122,7 +122,7 @@ class SignUpView: UIView, Form {
         email.type = .email
         password.type = .password
 
-        let fields = self.stackView.arrangedSubviews.map { $0 as? InputField }.filter { $0 != nil }.map { $0! }
+        let fields = self.stackView.arrangedSubviews.compactMap { $0 as? InputField }.filter { !$0.isHidden }
         fields.indices.dropLast().forEach {
             fields[$0].returnKey = .next
             fields[$0].nextField = fields[$0+1]

--- a/LockTests/InputFieldSpec.swift
+++ b/LockTests/InputFieldSpec.swift
@@ -110,7 +110,6 @@ class InputFieldSpec: QuickSpec {
                 expect(text.keyboardType) == UIKeyboardType.default
             }
 
-
             it("should assign phone type") {
                 input.type = .phone
                 expect(text.keyboardType) == UIKeyboardType.phonePad
@@ -122,8 +121,231 @@ class InputFieldSpec: QuickSpec {
             }
 
             it("should assign custom type") {
-                input.type = .custom(name: "test", placeholder: "", storage: .userMetadata, icon: nil, keyboardType: .twitter, autocorrectionType: .no, secure: false, contentType: nil)
+                input.type = .custom(name: "test", placeholder: "", defaultValue: nil, storage: .userMetadata, icon: nil, keyboardType: .twitter, autocorrectionType: .no, autocapitalizationType: .none, secure: false, hidden: false, contentType: nil)
                 expect(text.keyboardType) == UIKeyboardType.twitter
+            }
+        }
+
+        describe("autocorrect type") {
+            var input: InputField!
+            var text: UITextField!
+
+            beforeEach {
+                input = InputField()
+                text = input.textField
+            }
+
+            it("should assign email type") {
+                input.type = .email
+                expect(text.autocorrectionType) == .no
+            }
+
+            it("should assign username type") {
+                input.type = .username
+                expect(text.autocorrectionType) == .no
+            }
+
+            it("should assign emailOrUsername type") {
+                input.type = .emailOrUsername
+                expect(text.autocorrectionType) == .no
+            }
+
+            it("should assign password type") {
+                input.type = .password
+                expect(text.autocorrectionType) == .no
+            }
+
+            it("should assign phone type") {
+                input.type = .phone
+                expect(text.autocorrectionType) == .no
+            }
+
+            it("should assign oneTimePassword type") {
+                input.type = .oneTimePassword
+                expect(text.autocorrectionType) == .no
+            }
+
+            it("should assign custom type") {
+                input.type = .custom(name: "test", placeholder: "", defaultValue: nil, storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .yes, autocapitalizationType: .none, secure: false, hidden: false, contentType: nil)
+                expect(text.autocorrectionType) == .yes
+            }
+        }
+
+        describe("autocapitalization type") {
+            var input: InputField!
+            var text: UITextField!
+
+            beforeEach {
+                input = InputField()
+                text = input.textField
+            }
+
+            it("should assign email type") {
+                input.type = .email
+                expect(text.autocapitalizationType) == UITextAutocapitalizationType.none
+            }
+
+            it("should assign username type") {
+                input.type = .username
+                expect(text.autocapitalizationType) == UITextAutocapitalizationType.none
+            }
+
+            it("should assign emailOrUsername type") {
+                input.type = .emailOrUsername
+                expect(text.autocapitalizationType) == UITextAutocapitalizationType.none
+            }
+
+            it("should assign password type") {
+                input.type = .password
+                expect(text.autocapitalizationType) == UITextAutocapitalizationType.none
+            }
+
+            it("should assign phone type") {
+                input.type = .phone
+                expect(text.autocapitalizationType) == UITextAutocapitalizationType.none
+            }
+
+            it("should assign oneTimePassword type") {
+                input.type = .oneTimePassword
+                expect(text.autocapitalizationType) == UITextAutocapitalizationType.none
+            }
+
+            it("should assign custom type") {
+                input.type = .custom(name: "test", placeholder: "", defaultValue: nil, storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .default, autocapitalizationType: .words, secure: false, hidden: false, contentType: nil)
+                expect(text.autocapitalizationType) == .words
+            }
+        }
+
+        describe("default value") {
+            var input: InputField!
+            var text: UITextField!
+
+            beforeEach {
+                input = InputField()
+                text = input.textField
+            }
+
+            it("should assign email value") {
+                input.type = .email
+                expect(text.text?.isEmpty ?? true) == true
+            }
+
+            it("should assign username value") {
+                input.type = .username
+                expect(text.text?.isEmpty ?? true) == true
+            }
+
+            it("should assign emailOrUsername value") {
+                input.type = .emailOrUsername
+                expect(text.text?.isEmpty ?? true) == true
+            }
+
+            it("should assign password value") {
+                input.type = .password
+                expect(text.text?.isEmpty ?? true) == true
+            }
+
+            it("should assign phone value") {
+                input.type = .phone
+                expect(text.text?.isEmpty ?? true) == true
+            }
+
+            it("should assign oneTimePassword value") {
+                input.type = .oneTimePassword
+                expect(text.text?.isEmpty ?? true) == true
+            }
+
+            it("should assign custom value") {
+                input.type = .custom(name: "test", placeholder: "", defaultValue: "Default Value", storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .default, autocapitalizationType: .none, secure: true, hidden: false, contentType: nil)
+                expect(text.text) == "Default Value"
+            }
+        }
+
+        describe("secure value") {
+            var input: InputField!
+            var text: UITextField!
+
+            beforeEach {
+                input = InputField()
+                text = input.textField
+            }
+
+            it("should assign email value") {
+                input.type = .email
+                expect(text.isSecureTextEntry) == false
+            }
+
+            it("should assign username value") {
+                input.type = .username
+                expect(text.isSecureTextEntry) == false
+            }
+
+            it("should assign emailOrUsername value") {
+                input.type = .emailOrUsername
+                expect(text.isSecureTextEntry) == false
+            }
+
+            it("should assign password value") {
+                input.type = .password
+                expect(text.isSecureTextEntry) == true
+            }
+
+            it("should assign phone value") {
+                input.type = .phone
+                expect(text.isSecureTextEntry) == false
+            }
+
+            it("should assign oneTimePassword value") {
+                input.type = .oneTimePassword
+                expect(text.isSecureTextEntry) == false
+            }
+
+            it("should assign custom value") {
+                input.type = .custom(name: "test", placeholder: "", defaultValue: nil, storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .default, autocapitalizationType: .words, secure: true, hidden: false, contentType: nil)
+                expect(text.isSecureTextEntry) == true
+            }
+        }
+
+        describe("hidden value") {
+            var input: InputField!
+
+            beforeEach {
+                input = InputField()
+            }
+
+            it("should assign email value") {
+                input.type = .email
+                expect(input.isHidden) == false
+            }
+
+            it("should assign username value") {
+                input.type = .username
+                expect(input.isHidden) == false
+            }
+
+            it("should assign emailOrUsername value") {
+                input.type = .emailOrUsername
+                expect(input.isHidden) == false
+            }
+
+            it("should assign password value") {
+                input.type = .password
+                expect(input.isHidden) == false
+            }
+
+            it("should assign phone value") {
+                input.type = .phone
+                expect(input.isHidden) == false
+            }
+
+            it("should assign oneTimePassword value") {
+                input.type = .oneTimePassword
+                expect(input.isHidden) == false
+            }
+
+            it("should assign custom value") {
+                input.type = .custom(name: "test", placeholder: "", defaultValue: nil, storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .default, autocapitalizationType: .words, secure: false, hidden: true, contentType: nil)
+                expect(input.isHidden) == true
             }
         }
 
@@ -182,7 +404,7 @@ class InputFieldSpec: QuickSpec {
 
             if #available(iOS 10.0, *) {
                 it("should assign custom type") {
-                    input.type = .custom(name: "test", placeholder: "", storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .no, secure: false, contentType: .name)
+                    input.type = .custom(name: "test", placeholder: "", defaultValue: nil, storage: .userMetadata, icon: nil, keyboardType: .default, autocorrectionType: .no, autocapitalizationType: .none, secure: false, hidden: false, contentType: .name)
                     expect(text.textContentType) == UITextContentType.name
                 }
             }

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -480,7 +480,7 @@ class DatabasePresenterSpec: QuickSpec {
 
                 it("should custom field") {
                     let name = "Auth0"
-                    let input = mockInput(.custom(name: "first_name", placeholder: "Name", storage: .userMetadata, icon: LazyImage(name: "ic_auth0", bundle: Lock.bundle), keyboardType: .default, autocorrectionType: .no, secure: false, contentType: nil), value: name)
+                    let input = mockInput(.custom(name: "first_name", placeholder: "Name", defaultValue: nil, storage: .userMetadata, icon: LazyImage(name: "ic_auth0", bundle: Lock.bundle), keyboardType: .default, autocorrectionType: .no, autocapitalizationType: .none, secure: false, hidden: false, contentType: nil), value: name)
                     view.form?.onValueChange(input)
                     expect(interactor.custom["first_name"]) == name
                 }

--- a/README.md
+++ b/README.md
@@ -419,11 +419,15 @@ When signing up the default information requirements are the user's *email* and 
 
 If you want to save the value of the attribute in the root of a user's profile, ensure you set the  `storage` parameter to `.rootAttribute`. Only a subset of values can be stored this way. The list of attributes that can be added to your root profile is [here](https://auth0.com/docs/api/authentication#signup). By default, every additional sign up field is stored inside the user's `user_metadata` object.
 
+When signing up, your app may need to assign values to the user's profile that are not entered by the user. The `hidden` property of `CustomTextField` prevents the signup field from being shown to the user. Allowing your app to assign default values to the user profile.
+
+
 ```swift
 .withOptions {
   $0.customSignupFields = [
     CustomTextField(name: "first_name", placeholder: "First Name", storage: .rootAttribute, icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .givenName),
-    CustomTextField(name: "last_name", placeholder: "Last Name", storage: .rootAttribute, icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .familyName)
+    CustomTextField(name: "last_name", placeholder: "Last Name", storage: .rootAttribute, icon: LazyImage(name: "ic_person", bundle: Lock.bundle), contentType: .familyName),
+    CustomTextField(name: "referral_code", placeholder: "Referral Code", defaultValue: referralCode, hidden: true)
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ When signing up the default information requirements are the user's *email* and 
 
 If you want to save the value of the attribute in the root of a user's profile, ensure you set the  `storage` parameter to `.rootAttribute`. Only a subset of values can be stored this way. The list of attributes that can be added to your root profile is [here](https://auth0.com/docs/api/authentication#signup). By default, every additional sign up field is stored inside the user's `user_metadata` object.
 
-When signing up, your app may need to assign values to the user's profile that are not entered by the user. The `hidden` property of `CustomTextField` prevents the signup field from being shown to the user. Allowing your app to assign default values to the user profile.
+When signing up, your app may need to assign values to the user's profile that are not entered by the user. The `hidden` property of `CustomTextField` prevents the signup field from being shown to the user, allowing your app to assign default values to the user profile.
 
 
 ```swift


### PR DESCRIPTION
Followup from PR #570. These changes are intended to provide a way to pass through user metadata during account creation. In contrast to the key/values map approach in PR #570, this PR creates hidden UI fields that have their value assigned programmatically. This is based on the [conclusion in this comment](https://github.com/auth0/Lock.swift/pull/570#issuecomment-559579924). Creating `UIViews` that is never intended to be shown is inefficient. But is required to use the existing array of `CustomSignupFields` & not breaking the interface & not needing to refactor all the code that depends on `InputField` views being created for each of the values in the `customSignupFields` array.

### Changes

- Adds option to set a `CustomTextField` to hidden
- Adds option to set a `CustomTextField` value (required to passthrough values in hidden field)
- Adds option to set a `CustomTextField` autocapitalization type
- Corrects the setting of the `CustomTextField` autocorrection type

### References

- [Original pull request #570](https://github.com/auth0/Lock.swift/pull/570)
- [Comment](https://github.com/auth0/Lock.swift/pull/570#issuecomment-559579924) suggesting to use the existing `CustomTextField` type with the addition of making it hidden

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed