### PR TITLE
Allow rule text color customization [SDK-1243]

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -258,6 +258,9 @@ func applyPhantomStyle(_ style: inout Style) {
 
     // Table View
     style.searchBarStyle = .minimal
+    
+    // Password Rule Label
+    style.ruleTextColor = darkPurple
 }
 
 class CleanroomLockLogger: LoggerOutput {

--- a/Lock/DatabaseOnlyView.swift
+++ b/Lock/DatabaseOnlyView.swift
@@ -145,6 +145,9 @@ class DatabaseOnlyView: UIView, DatabaseView {
 
         if let passwordPolicyValidator = passwordPolicyValidator {
             let passwordPolicyView = PolicyView(rules: passwordPolicyValidator.policy.rules)
+            if let style = style {
+                passwordPolicyView.styleSubViews(style: style)
+            }
             passwordPolicyValidator.delegate = passwordPolicyView
             let passwordIndex = form.stackView.arrangedSubviews.firstIndex(of: form.passwordField)
             form.stackView.insertArrangedSubview(passwordPolicyView, at: passwordIndex!)

--- a/Lock/PolicyView.swift
+++ b/Lock/PolicyView.swift
@@ -72,6 +72,12 @@ class RuleView: UIView {
         }
     }
     let label: UILabel
+    
+    private var style = Style.Auth0 {
+        didSet {
+            self.render(text: self.message, withStatus: self.status)
+        }
+    }
 
     init(message: String, level: Int = 0) {
         self.message = message
@@ -114,14 +120,14 @@ class RuleView: UIView {
             }
         }
 
-        var color: UIColor {
+        func color(from style: Style) -> UIColor {
             switch self {
             case .ok:
-                return UIColor(red: 0.502, green: 0.820, blue: 0.208, alpha: 1)
+                return style.ruleTextColorSuccess
             case .error:
-                return UIColor(red: 0.745, green: 0.271, blue: 0.153, alpha: 1)
+                return style.ruleTextColorError
             case .none:
-                return UIColor(red: 0.016, green: 0.016, blue: 0.016, alpha: 1)
+                return style.ruleTextColor
             }
         }
     }
@@ -138,10 +144,16 @@ class RuleView: UIView {
         attributedText.append(NSAttributedString(
             string: "  " + text,
             attributes: [
-                NSAttributedString.attributedKeyColor: status.color,
+                NSAttributedString.attributedKeyColor: status.color(from: style),
                 NSAttributedString.attributedFont: font
             ]
         ))
         self.label.attributedText = attributedText
+    }
+}
+
+extension RuleView: Stylable {
+    func apply(style: Style) {
+        self.style = style
     }
 }

--- a/Lock/Style.swift
+++ b/Lock/Style.swift
@@ -105,6 +105,15 @@ public struct Style {
 
         /// Input field icon color
     public var inputIconColor = UIColor(red: 0.5725, green: 0.5804, blue: 0.5843, alpha: 1.0)
+    
+        /// Password rule text color default
+    public var ruleTextColor = UIColor(red: 0.016, green: 0.016, blue: 0.016, alpha: 1.0)
+    
+        /// Password rule text color valid
+    public var ruleTextColorSuccess = UIColor(red: 0.502, green: 0.820, blue: 0.208, alpha: 1.0)
+    
+        /// Password rule text color invalid
+    public var ruleTextColorError = UIColor(red: 0.745, green: 0.271, blue: 0.153, alpha: 1.0)
 
         /// Secondary button color
     public var secondaryButtonColor = UIColor.black

--- a/LockTests/Models/AuthStyleSpec.swift
+++ b/LockTests/Models/AuthStyleSpec.swift
@@ -117,7 +117,7 @@ class AuthStyleSpec: QuickSpec {
             [
                 forStyle(.Amazon, name: "AMAZON", iconName: "ic_auth_amazon"),
                 forStyle(.Aol, name: "AOL", iconName: "ic_auth_aol"),
-                forStyle(.Apple, name: "Apple", iconName: "ic_auth_apple"),
+                forStyle(.Apple, name: "APPLE", iconName: "ic_auth_apple"),
                 forStyle(.Baidu, name: "百度", iconName: "ic_auth_baidu"),
                 forStyle(.Bitbucket, name: "BITBUCKET", iconName: "ic_auth_bitbucket"),
                 forStyle(.Dropbox, name: "DROPBOX", iconName: "ic_auth_dropbox"),

--- a/LockTests/Models/AuthStyleSpec.swift
+++ b/LockTests/Models/AuthStyleSpec.swift
@@ -117,7 +117,7 @@ class AuthStyleSpec: QuickSpec {
             [
                 forStyle(.Amazon, name: "AMAZON", iconName: "ic_auth_amazon"),
                 forStyle(.Aol, name: "AOL", iconName: "ic_auth_aol"),
-                forStyle(.Apple, name: "APPLE", iconName: "ic_auth_apple"),
+                forStyle(.Apple, name: "Apple", iconName: "ic_auth_apple"),
                 forStyle(.Baidu, name: "百度", iconName: "ic_auth_baidu"),
                 forStyle(.Bitbucket, name: "BITBUCKET", iconName: "ic_auth_bitbucket"),
                 forStyle(.Dropbox, name: "DROPBOX", iconName: "ic_auth_dropbox"),

--- a/LockTests/PolicyViewSpec.swift
+++ b/LockTests/PolicyViewSpec.swift
@@ -39,6 +39,8 @@ class PolicyViewSpec: QuickSpec {
         }
 
         context("rule view") {
+            
+            let style = Style.Auth0
 
             describe("init") {
 
@@ -49,7 +51,7 @@ class PolicyViewSpec: QuickSpec {
 
                 it("should have default color of status none") {
                     let ruleView = RuleView(message: "MY RULE")
-                    expect(ruleView.status.color) == UIColor(red: 0.016, green: 0.016, blue: 0.016, alpha: 1)
+                    expect(ruleView.status.color(from: style)) == Style.Auth0.ruleTextColor
                 }
 
             }
@@ -61,10 +63,15 @@ class PolicyViewSpec: QuickSpec {
                 beforeEach {
                     ruleView = RuleView(message: "MY RULE")
                 }
+                
+                it("should change status color to success") {
+                    ruleView.status = .ok
+                    expect(ruleView.status.color(from: style)) == Style.Auth0.ruleTextColorSuccess
+                }
 
                 it("should change status color to error") {
                     ruleView.status = .error
-                    expect(ruleView.status.color) == UIColor(red: 0.745, green: 0.271, blue: 0.153, alpha: 1)
+                    expect(ruleView.status.color(from: style)) == Style.Auth0.ruleTextColorError
                 }
 
             }


### PR DESCRIPTION
### Changes

This PR builds upon the [original one](https://github.com/auth0/Lock.swift/pull/569) by @sochalewski by keeping all the existing test cases and adding a new one.

### References

- Closes #569 
- Fixes #567

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed