### PR TITLE
Made email/domain match case-insensitive

### DIFF
--- a/Lock/Colors.swift
+++ b/Lock/Colors.swift
@@ -24,7 +24,7 @@ import UIKit
 
 public extension UIColor {
 
-    static var a0_orange: UIColor { return UIColor ( red: 0.9176, green: 0.3255, blue: 0.1373, alpha: 1.0 ) }
+    static var a0_orange: UIColor { return UIColor(red: 0.9176, green: 0.3255, blue: 0.1373, alpha: 1.0) }
 
     static func a0_fromRGB(_ string: String, defaultColor: UIColor = .a0_orange) -> UIColor {
         guard string.hasPrefix("#") else { return defaultColor }

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -217,7 +217,7 @@ class DatabasePresenter: Presentable, Loggable {
         }
         view.primaryButton?.onPress = checkTermsAndSignup
         view.secondaryButton?.title = "By signing up, you agree to our terms of\n service and privacy policy".i18n(key: "com.auth0.lock.database.button.tos", comment: "tos & privacy")
-        view.secondaryButton?.color = UIColor ( red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0 )
+        view.secondaryButton?.color = UIColor(red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0)
         view.secondaryButton?.onPress = { button in
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
             alert.popoverPresentationController?.sourceView = button

--- a/Lock/EnterpriseDomainInteractor.swift
+++ b/Lock/EnterpriseDomainInteractor.swift
@@ -65,7 +65,7 @@ struct EnterpriseDomainInteractor: HRDAuthenticatable {
         }
 
         self.connection = nil
-        if let domain = value?.components(separatedBy: "@").last {
+        if let domain = value?.components(separatedBy: "@").last?.lowercased() {
             self.connection = match(domain: domain)
             self.domain = domain
         }

--- a/Lock/HeaderView.swift
+++ b/Lock/HeaderView.swift
@@ -103,7 +103,7 @@ public class HeaderView: UIView {
         }
     }
 
-    public var maskColor: UIColor = UIColor ( red: 0.8745, green: 0.8745, blue: 0.8745, alpha: 1.0 ) {
+    public var maskColor: UIColor = UIColor(red: 0.8745, green: 0.8745, blue: 0.8745, alpha: 1.0) {
         didSet {
             self.mask?.tintColor = self.maskColor
         }
@@ -204,7 +204,7 @@ public class HeaderView: UIView {
         self.maskImageView?.removeFromSuperview()
         self.blurView?.removeFromSuperview()
 
-        self.backgroundColor = self.canBlur ? .white : UIColor ( red: 0.9451, green: 0.9451, blue: 0.9451, alpha: 1.0 )
+        self.backgroundColor = self.canBlur ? .white : UIColor(red: 0.9451, green: 0.9451, blue: 0.9451, alpha: 1.0)
 
         guard self.canBlur else { return }
 

--- a/Lock/MessageView.swift
+++ b/Lock/MessageView.swift
@@ -53,9 +53,9 @@ class MessageView: UIView {
         var color: UIColor {
             switch self {
             case .success:
-                return UIColor ( red: 0.4941, green: 0.8275, blue: 0.1294, alpha: 1.0 )
+                return UIColor(red: 0.4941, green: 0.8275, blue: 0.1294, alpha: 1.0)
             case .failure:
-                return UIColor ( red: 1.0, green: 0.2431, blue: 0.0, alpha: 1.0 )
+                return UIColor(red: 1.0, green: 0.2431, blue: 0.0, alpha: 1.0)
             }
         }
     }

--- a/Lock/OptionBuildable.swift
+++ b/Lock/OptionBuildable.swift
@@ -129,7 +129,7 @@ extension OptionBuildable {
         guard self.oidcConformant || self.audience == nil else { return UnrecoverableError.invalidOptions(cause: "Must set OIDC-Conformant flag in Lock to use audience option") }
         return nil
     }
-    
+
 }
 
 public extension OptionBuildable {

--- a/Lock/PolicyView.swift
+++ b/Lock/PolicyView.swift
@@ -72,7 +72,7 @@ class RuleView: UIView {
         }
     }
     let label: UILabel
-    
+
     private var style = Style.Auth0 {
         didSet {
             self.render(text: self.message, withStatus: self.status)

--- a/Lock/SingleInputView.swift
+++ b/Lock/SingleInputView.swift
@@ -114,7 +114,7 @@ class SingleInputView: UIView, Form, Stylable {
 
         titleView.textAlignment = .center
         titleView.font = regularSystemFont(size: 26)
-        titleView.textColor = UIColor ( red: 0.2, green: 0.2, blue: 0.2, alpha: 1.0 )
+        titleView.textColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 1.0)
         messageView.numberOfLines = 4
         messageView.textAlignment = .center
         messageView.font = regularSystemFont(size: 15)

--- a/Lock/Style.swift
+++ b/Lock/Style.swift
@@ -105,13 +105,13 @@ public struct Style {
 
         /// Input field icon color
     public var inputIconColor = UIColor(red: 0.5725, green: 0.5804, blue: 0.5843, alpha: 1.0)
-    
+
         /// Password rule text color default
     public var ruleTextColor = UIColor(red: 0.016, green: 0.016, blue: 0.016, alpha: 1.0)
-    
+
         /// Password rule text color valid
     public var ruleTextColorSuccess = UIColor(red: 0.502, green: 0.820, blue: 0.208, alpha: 1.0)
-    
+
         /// Password rule text color invalid
     public var ruleTextColorError = UIColor(red: 0.745, green: 0.271, blue: 0.153, alpha: 1.0)
 

--- a/LockTests/Interactors/EnterpriseDomainInteractorSpec.swift
+++ b/LockTests/Interactors/EnterpriseDomainInteractorSpec.swift
@@ -117,6 +117,11 @@ class EnterpriseDomainInteractorSpec: QuickSpec {
                     try! enterprise.updateEmail("user@test.com")
                     expect(enterprise.connection?.name) == "TestAD"
                 }
+                
+                it("should case-insensitively match email domain and provide enteprise connection") {
+                    try! enterprise.updateEmail("user@tEsT.com")
+                    expect(enterprise.connection?.name) == "TestAD"
+                }
 
                 it("should not match connection with unknown domain") {
                     try! enterprise.updateEmail("user@domainnotmatched.com")


### PR DESCRIPTION
### Changes

- The user email is now matched case-insensitively against the enterprise connection domain, like in [Lock.Android](https://github.com/auth0/Lock.Android).
- Fixed whitespace warnings.

### References

- Closes #589

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed