### PR TITLE
Internationalised hardcoded strings

### DIFF
--- a/Lock/Base.lproj/Lock.strings
+++ b/Lock/Base.lproj/Lock.strings
@@ -16,6 +16,8 @@
 "com.auth0.lock.database.separator" = "or";
 // User signed up
 "com.auth0.lock.database.signup.success.message" = "Thanks for signing up.";
+// Accept
+"com.auth0.lock.database.tos.sheet.accept" = "Accept";
 // Cancel
 "com.auth0.lock.database.tos.sheet.cancel" = "Cancel";
 // Privacy

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -280,8 +280,8 @@ class DatabasePresenter: Presentable, Loggable {
         let alert = UIAlertController(title: terms, message: "By signing up, you agree to our terms of\n service and privacy policy".i18n(key: "com.auth0.lock.database.button.tos", comment: "tos & privacy"), preferredStyle: .alert)
         alert.popoverPresentationController?.sourceView = button
         alert.popoverPresentationController?.sourceRect = button.bounds
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
-        let okAction = UIAlertAction(title: "Accept", style: .default) { _ in
+        let cancelAction = UIAlertAction(title: "Cancel".i18n(key: "com.auth0.lock.database.tos.sheet.cancel", comment: "Cancel"), style: .cancel, handler: nil)
+        let okAction = UIAlertAction(title: "Accept".i18n(key: "com.auth0.lock.database.tos.sheet.accept", comment: "Accept"), style: .default) { _ in
             successHandler(button)
         }
         [cancelAction, okAction].forEach { alert.addAction($0) }

--- a/Lock/Validators.swift
+++ b/Lock/Validators.swift
@@ -130,7 +130,7 @@ public class PasswordPolicyValidator: InputValidator {
     func validate(_ value: String?) -> Error? {
         let result = self.policy.on(value)
         self.delegate?.update(withRules: result)
-        let valid = result.reduce(true) { $0 && $1.valid }
+        let valid = result.allSatisfy { $0.valid }
         guard !valid else { return nil }
         return InputValidationError.passwordPolicyViolation(result: result.filter { !$0.valid })
     }


### PR DESCRIPTION
### Changes

- Added a string resource to the strings file.
- Called the i18n method on two hardcoded strings.
- Fixed a linter warning regarding the usage of `reduce(true)` instead of `allSatisfy`.

### References

Closes https://github.com/auth0/Lock.swift/issues/575.

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed