### PR TITLE
Release 2.15.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.15.0](https://github.com/auth0/Lock.swift/tree/2.15.0) (2020-02-06)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.14.0...2.15.0)
+
+**Added**
+- Integrated ID Token Validation on WebAuth [SDK-982] [\#596](https://github.com/auth0/Lock.swift/pull/596) ([Widcket](https://github.com/Widcket))
+
+**Fixed**
+- Internationalised hardcoded strings [\#595](https://github.com/auth0/Lock.swift/pull/595) ([Widcket](https://github.com/Widcket))
+- Made email/domain match case-insensitive [\#594](https://github.com/auth0/Lock.swift/pull/594) ([Widcket](https://github.com/Widcket))
+
 ## [2.14.0](https://github.com/auth0/Lock.swift/tree/2.14.0) (2020-01-06)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.13.2...2.14.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.15.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
  Add the following line to your Podfile:
 
  ```ruby
- pod "Lock", "~> 2.14"
+ pod "Lock", "~> 2.15"
  ```
 
 ### Carthage
@@ -39,7 +39,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md)
 In your `Cartfile` add
 
 ```ruby
-github "auth0/Lock.swift" ~> 2.14
+github "auth0/Lock.swift" ~> 2.15
 ```
 
 ## Usage


### PR DESCRIPTION
**Added**
- Integrated ID Token Validation on WebAuth [SDK-982] [\#596](https://github.com/auth0/Lock.swift/pull/596) ([Widcket](https://github.com/Widcket))

**Fixed**
- Internationalised hardcoded strings [\#595](https://github.com/auth0/Lock.swift/pull/595) ([Widcket](https://github.com/Widcket))
- Made email/domain match case-insensitive [\#594](https://github.com/auth0/Lock.swift/pull/594) ([Widcket](https://github.com/Widcket))

[SDK-982]: https://auth0team.atlassian.net/browse/SDK-982