### PR TITLE
Update AuthButton style to match Lock.js [SDK-1376]

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -120,8 +120,8 @@ class ViewController: UIViewController {
                     .withConnections { connections in
                         connections.social(name: "apple", style: .Apple)
                         connections.social(name: "facebook", style: .Facebook)
+                        connections.social(name: "github", style: .Github)
                         connections.social(name: "google-oauth2", style: .Google)
-                        connections.social(name: "twitter", style: .Twitter)
                         connections.database(name: "Username-Password-Authentication", requiresUsername: false)
                 }
             },

--- a/Lock/AuthButton.swift
+++ b/Lock/AuthButton.swift
@@ -25,6 +25,7 @@ import UIKit
 public class AuthButton: UIView {
 
     weak var button: UIButton?
+    weak var iconView: UIImageView?
 
     public var color: UIColor {
         get {
@@ -53,7 +54,7 @@ public class AuthButton: UIView {
     public var borderColor: UIColor? {
         didSet {
             if let borderColor = self.borderColor {
-                self.layer.borderWidth = 2
+                self.layer.borderWidth = 1
                 self.layer.borderColor = borderColor.cgColor
             } else {
                 self.layer.borderWidth = 0
@@ -64,9 +65,9 @@ public class AuthButton: UIView {
 
     public var titleColor: UIColor = .white {
         didSet {
+            self.iconView?.tintColor = self.titleColor
             self.button?.setTitleColor(self.titleColor, for: .normal)
             self.button?.tintColor = self.titleColor
-            self.button?.imageView?.tintColor = self.titleColor
         }
     }
 
@@ -79,10 +80,10 @@ public class AuthButton: UIView {
 
     public var icon: UIImage? {
         get {
-            return self.button?.image(for: .normal)
+            return self.iconView?.image
         }
         set {
-            self.button?.setImage(newValue, for: .normal)
+            self.iconView?.image = newValue
         }
     }
 
@@ -130,7 +131,16 @@ public class AuthButton: UIView {
         self.layer.masksToBounds = true
 
         let button = UIButton(type: .custom)
+        let iconView = UIImageView()
+
         self.addSubview(button)
+        button.addSubview(iconView)
+
+        constraintEqual(anchor: iconView.leftAnchor, toAnchor: button.leftAnchor)
+        constraintEqual(anchor: iconView.topAnchor, toAnchor: button.topAnchor)
+        constraintEqual(anchor: iconView.bottomAnchor, toAnchor: button.bottomAnchor)
+        constraintEqual(anchor: iconView.widthAnchor, toAnchor: iconView.heightAnchor)
+        iconView.translatesAutoresizingMaskIntoConstraints = false
 
         constraintEqual(anchor: button.leftAnchor, toAnchor: self.leftAnchor)
         constraintEqual(anchor: button.topAnchor, toAnchor: self.topAnchor)
@@ -142,12 +152,11 @@ public class AuthButton: UIView {
         }
 
         dimension(dimension: button.heightAnchor, greaterThanOrEqual: 50)
-
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(self.icon ?? image(named: "ic_auth_auth0", compatibleWithTraitCollection: self.traitCollection),
-                        for: .normal)
-        button.imageView?.contentMode = .right
-        button.imageView?.tintColor = self.titleColor
+
+        iconView.image = self.icon ?? image(named: "ic_auth_auth0", compatibleWithTraitCollection: self.traitCollection)
+        iconView.contentMode = .center
+        iconView.tintColor = self.titleColor
 
         button.setBackgroundImage(image(withColor: self.color), for: .normal)
         button.setBackgroundImage(image(withColor: self.color.a0_darker(0.3)), for: .highlighted)
@@ -156,7 +165,7 @@ public class AuthButton: UIView {
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.titleLabel?.minimumScaleFactor = 0.5
         button.contentVerticalAlignment = .center
-        button.contentHorizontalAlignment = .center
+        button.contentHorizontalAlignment = .left
         button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
 
         if case .big = self.size {
@@ -164,15 +173,12 @@ public class AuthButton: UIView {
         }
 
         self.button = button
+        self.iconView = iconView
     }
 
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-
-        let spacing: CGFloat = 12 / 2
-        self.button?.imageEdgeInsets = UIEdgeInsets(top: 0, left: -spacing, bottom: 0, right: spacing)
-        self.button?.titleEdgeInsets = UIEdgeInsets(top: 0, left: spacing, bottom: 0, right: -spacing)
-        self.button?.contentEdgeInsets = UIEdgeInsets(top: 0, left: spacing, bottom: 0, right: spacing)
+    public override func updateConstraints() {
+        super.updateConstraints()
+        self.button?.titleEdgeInsets = UIEdgeInsets(top: 0, left: max(self.frame.size.height, 50) + 12, bottom: 0, right: 12)
     }
 
     public override var intrinsicContentSize: CGSize {

--- a/Lock/AuthStyle.swift
+++ b/Lock/AuthStyle.swift
@@ -39,7 +39,7 @@ public struct AuthStyle {
     }
 
     var localizedSignUpTitle: String {
-        let format = "Sign in with %1$@".i18n(key: "com.auth0.lock.strategy.signup.title", comment: "Sign in with %@{strategy}")
+        let format = "Sign up with %1$@".i18n(key: "com.auth0.lock.strategy.signup.title", comment: "Sign up with %@{strategy}")
         return String(format: format, self.name)
     }
 

--- a/Lock/Base.lproj/Lock.strings
+++ b/Lock/Base.lproj/Lock.strings
@@ -227,7 +227,7 @@
 // Log in with %@{strategy}
 "com.auth0.lock.strategy.login.title" = "Sign in with %1$@";
 // Sign up with %@{strategy}
-"com.auth0.lock.strategy.signup.title" = "Sign in with %1$@";
+"com.auth0.lock.strategy.signup.title" = "Sign up with %1$@";
 // Login Button title
 "com.auth0.lock.submit.login.title" = "LOG IN";
 // Send 2fa code

--- a/LockTests/AuthCollectionViewSpec.swift
+++ b/LockTests/AuthCollectionViewSpec.swift
@@ -98,7 +98,7 @@ class AuthCollectionViewSpec: QuickSpec {
 
             it("should set proper title") {
                 let button = styleButton(.Facebook, isLogin: false)
-                expect(button.title) == "Sign in with Facebook"
+                expect(button.title) == "Sign up with Facebook"
             }
 
             it("should set color") {

--- a/LockTests/Models/AuthStyleSpec.swift
+++ b/LockTests/Models/AuthStyleSpec.swift
@@ -111,7 +111,7 @@ class AuthStyleSpec: QuickSpec {
 
             it("should provide signup title") {
                 let strategy = AuthStyle(name: "facebook")
-                expect(strategy.localizedSignUpTitle) == "Sign in with facebook"
+                expect(strategy.localizedSignUpTitle) == "Sign up with facebook"
             }
 
         }


### PR DESCRIPTION
### Changes

Updated `AuthButton` to match the new [Lock.js](https://github.com/auth0/lock) style, that was in turn updated to prevent App Store rejections (due to the look of the SIWA button).

- Refactored the layout of `AuthButton` to re-add the original ImageView
- Left-aligned the button text
- Set the border width to 1
- Updated the tests

![Simulator Screen Shot - iPhone 11 - 2020-03-02 at 10 36 04](https://user-images.githubusercontent.com/5055789/75682240-d8695e80-5c73-11ea-9560-18f6393968ec.png)

### References

- Continues after #599 

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed