### PR TITLE
Fixes crash in banner presentation

### DIFF
--- a/Lock/AuthPresenter.swift
+++ b/Lock/AuthPresenter.swift
@@ -50,7 +50,9 @@ class AuthPresenter: Presentable, Loggable {
         let view = AuthCollectionView(connections: self.connections, mode: mode, insets: insets, customStyle: self.customStyle) { name in
             self.interactor.login(name, loginHint: nil) { error in
                 guard let error = error else { return }
-                self.messagePresenter?.showError(error)
+                Queue.main.async {
+                    self.messagePresenter?.showError(error)
+                }
             }
         }
         return view


### PR DESCRIPTION
### Changes

Always access the message presenter on the main queue.
Fixes a crash caused by accessing the message banner UI on a background thread. 

### References

Issue #602

### Testing

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed