### PR TITLE
Release 2.16.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.16.0</string>
+	<string>2.16.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.16.1](https://github.com/auth0/Lock.swift/tree/2.16.1) (2020-03-10)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.16.0...2.16.1)
+
+**Fixed**
+- Fixed crash in banner presentation [\#603](https://github.com/auth0/Lock.swift/pull/603) ([ejensen](https://github.com/ejensen))
+
 ## [2.16.0](https://github.com/auth0/Lock.swift/tree/2.16.0) (2020-03-02)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.15.0...2.16.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.16.0</string>
+	<string>2.16.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.16.0</string>
+	<string>2.16.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.16.0</string>
+	<string>2.16.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
**Fixed**
- Fixed crash in banner presentation [\#603](https://github.com/auth0/Lock.swift/pull/603) ([ejensen](https://github.com/ejensen))