### PR TITLE
Fixed signup form state bug [SDK-1490]

### DIFF
--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -160,6 +160,7 @@ class DatabasePresenter: Presentable, Loggable {
         self.currentScreen = .signup
         interactor?.user.reset()
         view.showSignUp(withUsername: self.database.requiresUsername, username: username, email: email, authCollectionView: authCollectionView, additionalFields: self.options.customSignupFields, passwordPolicyValidator: passwordPolicyValidator, showPassword: self.options.allowShowPassword, showTerms: options.showTerms || options.mustAcceptTerms)
+        view.allFields?.filter { $0.text != nil && !$0.text!.isEmpty }.forEach(self.handleInput)
         let form = view.form
         view.form?.onValueChange = self.handleInput
 


### PR DESCRIPTION
### Changes

In the context of a database signup, whenever the user updates a value in the signup form, [this](https://github.com/auth0/Lock.swift/blob/master/Lock/DatabasePresenter.swift#L233) input handler runs and validates the value. If the `mustAcceptTerms` option is enabled and the user taps the "Sign Up" button, the `DatabasePresenter` [will check](https://github.com/auth0/Lock.swift/blob/master/Lock/DatabasePresenter.swift#L206) that all fields are valid before proceeding with the signup button action. If they are valid, the Terms and Conditions alert will be displayed. Otherwise, no action will be taken.

But, if the user fills all the signup fields and switches to the "Log In" tab and then to "Sign Up" back again, the text fields will be recreated with their previous values, save for the password field (which will be empty). But the validations will never run, because these values were set using the `text` property setter instead of being input by the user. Therefore those fields will remain as `invalid`, and the Terms and Conditions alert will not be displayed:

![Bug](https://user-images.githubusercontent.com/5055789/78109258-4027dc00-73cf-11ea-858f-f43c64f8fb51.gif)

By running the input handler right after the form setup, the fields will have the proper validation state:

![Fix](https://user-images.githubusercontent.com/5055789/78111395-fc36d600-73d2-11ea-99b0-8a1fe003936d.gif)

### References

Fixes https://github.com/auth0/Lock.swift/issues/607

### Testing

This change was tested manually.

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed