### PR TITLE
Changed the background color to black

### DIFF
--- a/Lock/AuthStyle.swift
+++ b/Lock/AuthStyle.swift
@@ -134,7 +134,7 @@ public extension AuthStyle {
     static var Apple: AuthStyle {
         return AuthStyle(
                 name: "Apple".i18n(key: "com.auth0.lock.strategy.localized.apple", comment: "Apple"),
-                color: .a0_fromRGB("#1c1c1c"),
+                color: .a0_fromRGB("#000000"),
                 withImage: LazyImage(name: "ic_auth_apple", bundle: bundleForLock())
         )
     }


### PR DESCRIPTION
### Changes

The background color of the SIWA button was changed to black, as per Apple's [HIG](https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/buttons/).

![Simulator Screen Shot - iPhone 11 - 2020-04-19 at 12 51 04](https://user-images.githubusercontent.com/5055789/79692717-0f53fd80-823d-11ea-812c-415aff6afebf.png)

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed