### PR TITLE
Fixed input validation [SDK-913]

### DIFF
--- a/Lock/CredentialView.swift
+++ b/Lock/CredentialView.swift
@@ -43,6 +43,19 @@ class CredentialView: UIView, Form {
         }
     }
 
+    var onSubmit: (InputField) -> Bool = { _ in return true } {
+        didSet {
+            self.identityField.onSubmit = onSubmit
+            self.passwordField.onSubmit = onSubmit
+        }
+    }
+
+    func shouldSubmit() -> Bool {
+        let shouldSubmitIdentityField = self.identityField.onSubmit(self.identityField)
+        let shouldSubmitPasswordField = self.passwordField.onSubmit(self.passwordField)
+        return shouldSubmitIdentityField && shouldSubmitPasswordField
+    }
+
     func needsToUpdateState() {
         self.identityField.needsToUpdateState()
         self.passwordField.needsToUpdateState()

--- a/Lock/DatabaseForgotPasswordPresenter.swift
+++ b/Lock/DatabaseForgotPasswordPresenter.swift
@@ -58,11 +58,26 @@ class DatabaseForgotPasswordPresenter: Presentable, Loggable {
                 input.showError()
             }
         }
+
+        view.form?.onSubmit = { input in
+            view.form?.onValueChange(input)
+
+            do {
+                try self.interactor.updateEmail(input.text)
+                return true
+            } catch {
+                return false
+            }
+        }
+
         let action = { [weak form] (button: PrimaryButton) in
+            guard let isValid = view.form?.shouldSubmit(), isValid else { return }
+
             self.messagePresenter?.hideCurrent()
             self.logger.info("request forgot password for email: \(self.interactor.email.verbatim())")
             let interactor = self.interactor
             button.inProgress = true
+
             interactor.requestEmail { error in
                 Queue.main.async {
                     button.inProgress = false

--- a/Lock/Form.swift
+++ b/Lock/Form.swift
@@ -25,8 +25,11 @@ import Foundation
 protocol Form: class {
     var onValueChange: (InputField) -> Void { get set }
     var onReturn: (InputField) -> Void { get set }
-    func needsToUpdateState()
+    var onSubmit: (InputField) -> Bool { get set }
     var onCountryChange: (CountryCode) -> Void { get set }
+
+    func shouldSubmit() -> Bool
+    func needsToUpdateState()
 }
 
 extension Form {

--- a/Lock/InputField.swift
+++ b/Lock/InputField.swift
@@ -85,13 +85,15 @@ class InputField: UIView, Stylable {
         }
     }
 
-    var onTextChange: (InputField) -> Void = {_ in}
+    var onTextChange: (InputField) -> Void = { _ in }
 
-    var onReturn: (InputField) -> Void = {_ in}
+    var onReturn: (InputField) -> Void = { _ in }
 
-    var onBeginEditing: (InputField) -> Void = {_ in}
+    var onBeginEditing: (InputField) -> Void = { _ in }
 
-    var onEndEditing: (InputField) -> Void = {_ in}
+    var onEndEditing: (InputField) -> Void = { _ in }
+
+    var onSubmit: (InputField) -> Bool = { _ in return true }
 
     // MARK: - Initialisers
 

--- a/Lock/InternationalPhoneInputView.swift
+++ b/Lock/InternationalPhoneInputView.swift
@@ -102,6 +102,19 @@ class InternationalPhoneInputView: UIView, Form, Stylable {
         }
     }
 
+    var onSubmit: (InputField) -> Bool {
+        get {
+            return self.inputField.onSubmit
+        }
+        set {
+            self.inputField.onSubmit = newValue
+        }
+    }
+
+    func shouldSubmit() -> Bool {
+        return self.inputField.onSubmit(self.inputField)
+    }
+
     func needsToUpdateState() {
         self.inputField.needsToUpdateState()
     }

--- a/Lock/SignUpView.swift
+++ b/Lock/SignUpView.swift
@@ -60,8 +60,23 @@ class SignUpView: UIView, Form {
         }
     }
 
+    var onSubmit: (InputField) -> Bool = { _ in return true } {
+        didSet {
+            self.stackView.arrangedSubviews
+                .compactMap { $0 as? InputField }
+                .forEach { $0.onSubmit = onSubmit }
+        }
+    }
+
     var lastField: InputField? {
         return self.stackView.arrangedSubviews.last as? InputField
+    }
+
+    func shouldSubmit() -> Bool {
+        return !self.stackView.arrangedSubviews
+            .compactMap { $0 as? InputField }
+            .map { $0.onSubmit($0) }
+            .contains(false)
     }
 
     func needsToUpdateState() {
@@ -116,7 +131,7 @@ class SignUpView: UIView, Form {
 
         stackView.axis = .vertical
         stackView.spacing = 16
-        stackView.distribution = .fillProportionally
+        stackView.distribution = .fill
         stackView.alignment = .fill
 
         email.type = .email

--- a/Lock/SingleInputView.swift
+++ b/Lock/SingleInputView.swift
@@ -73,6 +73,19 @@ class SingleInputView: UIView, Form, Stylable {
         }
     }
 
+    var onSubmit: (InputField) -> Bool {
+        get {
+            return self.inputField.onSubmit
+        }
+        set {
+            self.inputField.onSubmit = newValue
+        }
+    }
+
+    func shouldSubmit() -> Bool {
+        return self.inputField.onSubmit(self.inputField)
+    }
+
     func needsToUpdateState() {
         self.inputField.needsToUpdateState()
     }

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -520,16 +520,46 @@ class DatabasePresenterSpec: QuickSpec {
                     expect(interactor.email) == email
                 }
 
+                it("should allow a valid email") {
+                    let input = mockInput(.email, value: email)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid email") {
+                    let input = mockInput(.email, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
+                }
+
                 it("should update username") {
                     let input = mockInput(.username, value: username)
                     view.form?.onValueChange(input)
                     expect(interactor.username) == username
                 }
 
+                it("should allow a valid username") {
+                    let input = mockInput(.username, value: username)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid username") {
+                    let input = mockInput(.username, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
+                }
+
                 it("should update password") {
                     let input = mockInput(.password, value: password)
                     view.form?.onValueChange(input)
                     expect(interactor.password) == password
+                }
+
+                it("should allow a valid password") {
+                    let input = mockInput(.password, value: password)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid password") {
+                    let input = mockInput(.password, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
                 }
 
                 it("should custom field") {

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -839,6 +839,7 @@ class DatabasePresenterSpec: QuickSpec {
                         presenter.enterpriseInteractor = enterpriseInteractor
                         
                         view = presenter.view as? DatabaseOnlyView
+                        view.form?.onSubmit = { _ in return true }
                         
                         let input = mockInput(.email, value: "user@valid.com")
                         view.form?.onValueChange(input)

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -277,10 +277,30 @@ class DatabasePresenterSpec: QuickSpec {
                     expect(interactor.email) == email
                 }
 
+                it("should allow a valid email") {
+                    let input = mockInput(.email, value: email)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid email") {
+                    let input = mockInput(.email, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
+                }
+
                 it("should update username") {
                     let input = mockInput(.username, value: username)
                     view.form?.onValueChange(input)
                     expect(interactor.username) == username
+                }
+
+                it("should allow a valid username") {
+                    let input = mockInput(.username, value: username)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid username") {
+                    let input = mockInput(.username, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
                 }
 
                 it("should update password") {
@@ -289,10 +309,30 @@ class DatabasePresenterSpec: QuickSpec {
                     expect(interactor.password) == password
                 }
 
+                it("should allow a valid password") {
+                    let input = mockInput(.password, value: password)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid password") {
+                    let input = mockInput(.password, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
+                }
+
                 it("should update username or email") {
                     let input = mockInput(.emailOrUsername, value: username)
                     view.form?.onValueChange(input)
                     expect(interactor.username) == username
+                }
+
+                it("should allow a valid username or email") {
+                    let input = mockInput(.emailOrUsername, value: username)
+                    expect(view.form?.onSubmit(input)) == true
+                }
+
+                it("should not allow an invalid username or email") {
+                    let input = mockInput(.emailOrUsername, value: "invalid")
+                    expect(view.form?.onSubmit(input)) == false
                 }
 
                 it("should not update if type is not valid for db connection") {

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -86,6 +86,20 @@ class DatabasePresenterSpec: QuickSpec {
             }
         }
 
+        describe("form submit") {
+
+            it("should allow form submit") {
+                view.form?.onSubmit = { _ in return true }
+                expect(view.form?.shouldSubmit()) == true
+            }
+
+            it("should not allow form submit") {
+                view.form?.onSubmit = { _ in return false }
+                expect(view.form?.shouldSubmit()) == false
+            }
+
+        }
+
         describe("accept terms alert") {
 
             it("present alert") {


### PR DESCRIPTION
### Changes

#### Forgot Password Form
Submitting an empty form marked the field with red but did not display the error message.
![IMG_5062](https://user-images.githubusercontent.com/5055789/84823459-bd3d1780-aff4-11ea-917a-7c3e0bf0bc86.jpg)
Now the error message is displayed correctly.
![IMG_5060](https://user-images.githubusercontent.com/5055789/84823463-be6e4480-aff4-11ea-913b-be7a0e901106.PNG)
Additionally it was allowed to submit the form with an invalid email address. This is no longer allowed.
![IMG_5061](https://user-images.githubusercontent.com/5055789/84823462-bdd5ae00-aff4-11ea-81b8-7df52c44905a.PNG)

#### Login Form
Submitting an empty form marked the fields with red but did not display the error messages.
![IMG_5063](https://user-images.githubusercontent.com/5055789/84823458-bca48100-aff4-11ea-9b21-832ecce0eb25.jpg)
Now the error messages are displayed correctly.
![IMG_5059](https://user-images.githubusercontent.com/5055789/84823464-bf06db00-aff4-11ea-9cef-03f72a194cf3.PNG)

#### Signup Form
Submitting an empty form marked the fields with red but did not display the error messages, except for the last field.
![IMG_5064](https://user-images.githubusercontent.com/5055789/84823453-b9a99080-aff4-11ea-82b7-f9fa6d698e16.jpg)
Now the error messages are displayed correctly.
![IMG_5056](https://user-images.githubusercontent.com/5055789/84823466-bf9f7180-aff4-11ea-983e-2582d87e591f.PNG)
Note that the password field has its own way to display the error message (only when it has focus).
![IMG_5058](https://user-images.githubusercontent.com/5055789/84823465-bf06db00-aff4-11ea-8f07-15e4a9e2ed36.PNG)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed