### PR TITLE
Fix password field icon

### DIFF
--- a/Lock/InputField.swift
+++ b/Lock/InputField.swift
@@ -229,6 +229,7 @@ class InputField: UIView, Stylable {
         constraintEqual(anchor: button.bottomAnchor, toAnchor: textField.bottomAnchor)
         constraintEqual(anchor: button.rightAnchor, toAnchor: container.rightAnchor)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentCompressionResistancePriority(UILayoutPriority.priorityRequired, for: .horizontal)
 
         return button
     }


### PR DESCRIPTION
### Changes

With long passwords, the icon to the right of the password field got distorted:
<img width="416" alt="Screen Shot 2020-06-18 at 16 41 10" src="https://user-images.githubusercontent.com/5055789/85065274-41bda080-b183-11ea-90d2-ffa111c0a430.png">

Now the icon does not get distorted anymore:
<img width="415" alt="Screen Shot 2020-06-18 at 16 44 40" src="https://user-images.githubusercontent.com/5055789/85065341-5e59d880-b183-11ea-92b3-20a4363ad8c3.png">

### References

Fixes #621 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed