### PR TITLE
Increased tappable surface of close button

### DIFF
--- a/Lock/HeaderView.swift
+++ b/Lock/HeaderView.swift
@@ -126,7 +126,7 @@ public class HeaderView: UIView {
     private func layoutHeader() {
         let titleView = UILabel()
         let logoView = UIImageView()
-        let closeButton = UIButton(type: .system)
+        let closeButton = CloseButton(type: .system)
         let backButton = UIButton(type: .system)
         let centerGuide = UILayoutGuide()
 
@@ -252,4 +252,12 @@ extension HeaderView: Stylable {
         self.backButton?.setBackgroundImage(style.headerBackIcon.image(compatibleWithTraits: self.traitCollection)?.withRenderingMode(.alwaysOriginal), for: .normal)
         self.closeButton?.setBackgroundImage(style.headerCloseIcon.image(compatibleWithTraits: self.traitCollection)?.withRenderingMode(.alwaysOriginal), for: .normal)
     }
+}
+
+private class CloseButton: UIButton {
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        return bounds.insetBy(dx: -10, dy: -10).contains(point)
+    }
+
 }

--- a/Lock/HeaderView.swift
+++ b/Lock/HeaderView.swift
@@ -127,7 +127,7 @@ public class HeaderView: UIView {
         let titleView = UILabel()
         let logoView = UIImageView()
         let closeButton = CloseButton(type: .system)
-        let backButton = UIButton(type: .system)
+        let backButton = CloseButton(type: .system)
         let centerGuide = UILayoutGuide()
 
         self.addLayoutGuide(centerGuide)


### PR DESCRIPTION
### Changes

This PR increases the tappable surface of the close button 10pt vertically and 10pt horizontally.

### References

Fixes https://github.com/auth0/Lock.swift/issues/634

### Testing

This change has been tested manually.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed