### PR TITLE
Release 2.19.1 [SDK-2002]

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.0</string>
+	<string>2.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.19.1](https://github.com/auth0/Lock.swift/tree/2.19.1) (2020-10-05)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.19.0...2.19.1
+
+**Changed**
+- Increased tappable surface of close and back buttons [\#635](https://github.com/auth0/Lock.swift/pull/635) ([Widcket](https://github.com/Widcket))
+- Updated 37 Signals icon and display name [SDK-1945] [\#633](https://github.com/auth0/Lock.swift/pull/633) ([Widcket](https://github.com/Widcket))
+
 ## [2.19.0](https://github.com/auth0/Lock.swift/tree/2.19.0) (2020-08-25)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.18.0...2.19.0)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.0</string>
+	<string>2.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.0</string>
+	<string>2.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.0</string>
+	<string>2.19.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
**Changed**
- Increased tappable surface of close and back buttons [\#635](https://github.com/auth0/Lock.swift/pull/635) ([Widcket](https://github.com/Widcket))
- Updated 37 Signals icon and display name [SDK-1945] [\#633](https://github.com/auth0/Lock.swift/pull/633) ([Widcket](https://github.com/Widcket))

[SDK-1945]: https://auth0team.atlassian.net/browse/SDK-1945