### PR TITLE
Fix bot detection CAPTCHA not being shown

### DIFF
--- a/Lock/Auth0OAuth2Interactor.swift
+++ b/Lock/Auth0OAuth2Interactor.swift
@@ -30,15 +30,15 @@ struct Auth0OAuth2Interactor: OAuth2Authenticatable, Loggable {
     let options: Options
     let nativeHandlers: [String: AuthProvider]
 
-    func start(_ connection: String, loginHint: String?, screenHint: String?, callback: @escaping (OAuth2AuthenticatableError?) -> Void) {
+    func start(_ connection: String, loginHint: String?, screenHint: String?, useEphemeralSession: Bool, callback: @escaping (OAuth2AuthenticatableError?) -> Void) {
         if let nativeHandler = self.nativeHandlers[connection], type(of: nativeHandler).isAvailable() {
             self.nativeAuth(withConnection: connection, nativeAuth: nativeHandler, callback: callback)
         } else {
-            self.webAuth(withConnection: connection, loginHint: loginHint, screenHint: screenHint, callback: callback)
+            self.webAuth(withConnection: connection, loginHint: loginHint, screenHint: screenHint, useEphemeralSession: useEphemeralSession, callback: callback)
         }
     }
 
-    private func webAuth(withConnection connection: String, loginHint: String?, screenHint: String?, callback: @escaping (OAuth2AuthenticatableError?) -> Void) {
+    private func webAuth(withConnection connection: String, loginHint: String?, screenHint: String?, useEphemeralSession: Bool, callback: @escaping (OAuth2AuthenticatableError?) -> Void) {
 
         var parameters: [String: String] = [:]
         self.options.parameters.forEach { parameters[$0] = "\($1)" }
@@ -49,6 +49,10 @@ struct Auth0OAuth2Interactor: OAuth2Authenticatable, Loggable {
             .webAuth(withConnection: connection)
             .scope(self.options.scope)
             .parameters(parameters)
+
+        if useEphemeralSession {
+            auth = auth.useEphemeralSession()
+        }
 
         auth = auth.logging(enabled: self.options.logHttpRequest)
 

--- a/Lock/AuthPresenter.swift
+++ b/Lock/AuthPresenter.swift
@@ -49,7 +49,7 @@ class AuthPresenter: Presentable, Loggable {
 
     private func newView(withInsets insets: UIEdgeInsets, mode: AuthCollectionView.Mode) -> AuthCollectionView {
         let view = AuthCollectionView(connections: self.connections, mode: mode, insets: insets, customStyle: self.customStyle) { name in
-            self.interactor.start(name, loginHint: nil, screenHint: nil) { error in
+            self.interactor.start(name, loginHint: nil, screenHint: nil, useEphemeralSession: false) { error in
                 guard let error = error else { return }
                 Queue.main.async {
                     self.messagePresenter?.showError(error)

--- a/Lock/ClassicRouter.swift
+++ b/Lock/ClassicRouter.swift
@@ -51,7 +51,7 @@ struct ClassicRouter: Router {
         case (.some(let database), let oauth2, let enterprise):
             guard self.lock.options.allow != [.ResetPassword] && self.lock.options.initialScreen != .resetPassword else { return forgotPassword }
             let authentication = self.lock.authentication
-            let webAuthInteractor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
+            let webAuthInteractor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
             let interactor = DatabaseInteractor(connection: database, authentication: authentication, webAuthentication: webAuthInteractor, user: self.user, options: self.lock.options, dispatcher: lock.observerStore)
             let presenter = DatabasePresenter(interactor: interactor, connection: database, navigator: self, options: self.lock.options)
             if !oauth2.isEmpty {

--- a/Lock/DatabaseInteractor.swift
+++ b/Lock/DatabaseInteractor.swift
@@ -135,6 +135,7 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
         let rootAttributes: [String: String]? = self.user.rootAttributes.isEmpty ? nil : self.user.rootAttributes
 
         let login = self.credentialAuth.request(withIdentifier: email, password: password, options: self.options)
+
         self.credentialAuth
             .authentication
             .createUser(

--- a/Lock/DatabaseInteractor.swift
+++ b/Lock/DatabaseInteractor.swift
@@ -119,10 +119,9 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
     func create(_ callback: @escaping (DatabaseUserCreatorError?, CredentialAuthError?) -> Void) {
         let databaseName = connection.name
 
-        guard
-            let email = self.email, self.validEmail,
-            let password = self.password, self.validPassword
-            else { return callback(.nonValidInput, nil) }
+        guard let email = self.email, self.validEmail, let password = self.password, self.validPassword else { 
+            return callback(.nonValidInput, nil)
+        }
 
         guard !connection.requiresUsername || self.validUsername else { return callback(.nonValidInput, nil) }
 

--- a/Lock/DatabaseInteractor.swift
+++ b/Lock/DatabaseInteractor.swift
@@ -109,11 +109,7 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
                 switch result {
                 case .failure(let error as AuthenticationError) where error.isVerificationRequired:
                     Queue.main.async {
-                        self.webAuth.start(self.connection.name, loginHint: identifier, screenHint: "login") { webAuthError in
-                            guard let webAuthError = webAuthError else { return callback(nil) }
-                            self.logger.error("Failed web-based verification of user <\(identifier)> with error \(webAuthError)")
-                            callback(.verificationFailure(error: webAuthError))
-                        }
+                        self.startWebAuth(loginHint: identifier, screenHint: "login", callback: callback)
                     }
                 default: self.handle(identifier: identifier, result: result, callback: callback)
                 }
@@ -170,11 +166,7 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
                     self.dispatcher.dispatch(result: .error(DatabaseUserCreatorError.passwordAlreadyUsed))
                 case .failure(let cause as AuthenticationError) where cause.isVerificationRequired:
                     Queue.main.async {
-                        self.webAuth.start(self.connection.name, loginHint: email, screenHint: "signup") { webAuthError in
-                            guard let webAuthError = webAuthError else { return callback(nil, nil) }
-                            self.logger.error("Failed web-based verification of user <\(email)> with error \(webAuthError)")
-                            callback(nil, .verificationFailure(error: webAuthError))
-                        }
+                        self.startWebAuth(loginHint: email, screenHint: "signup", callback: { callback(nil, $0) })
                     }
                 case .failure(let cause as AuthenticationError) where cause.code == "invalid_password" && cause.value("name") == "PasswordDictionaryError":
                     callback(.passwordTooCommon, nil)
@@ -192,6 +184,14 @@ struct DatabaseInteractor: DatabaseAuthenticatable, DatabaseUserCreator, Loggabl
                     callback(.couldNotCreateUser, nil)
                     self.dispatcher.dispatch(result: .error(DatabaseUserCreatorError.couldNotCreateUser))
                 }
+        }
+    }
+
+    private func startWebAuth(loginHint: String, screenHint: String, callback: @escaping (CredentialAuthError?) -> Void) {
+        self.webAuth.start(self.connection.name, loginHint: loginHint, screenHint: screenHint, useEphemeralSession: true) { webAuthError in
+            guard let webAuthError = webAuthError else { return callback(nil) }
+            self.logger.error("Failed web-based verification of user <\(loginHint)> with error \(webAuthError)")
+            callback(.verificationFailure(error: webAuthError))
         }
     }
 

--- a/Lock/EnterpriseDomainInteractor.swift
+++ b/Lock/EnterpriseDomainInteractor.swift
@@ -73,7 +73,7 @@ struct EnterpriseDomainInteractor: HRDAuthenticatable {
 
     func login(_ callback: @escaping (OAuth2AuthenticatableError?) -> Void) {
         guard let connection = self.connection else { return callback(.noConnectionAvailable) }
-        authenticator.start(connection.name, loginHint: self.email, screenHint: nil, callback: callback)
+        authenticator.start(connection.name, loginHint: self.email, screenHint: nil, useEphemeralSession: false, callback: callback)
     }
 
 }

--- a/Lock/OAuth2Authenticatable.swift
+++ b/Lock/OAuth2Authenticatable.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 protocol OAuth2Authenticatable {
-    func start(_ connection: String, loginHint: String?, screenHint: String?, callback: @escaping (OAuth2AuthenticatableError?) -> Void)
+    func start(_ connection: String, loginHint: String?, screenHint: String?, useEphemeralSession: Bool, callback: @escaping (OAuth2AuthenticatableError?) -> Void)
 }
 
 enum OAuth2AuthenticatableError: Error, LocalizableError {

--- a/LockTests/Interactors/Auth0OAuth2InteractorSpec.swift
+++ b/LockTests/Interactors/Auth0OAuth2InteractorSpec.swift
@@ -72,19 +72,19 @@ class Auth0OAuth2InteractorSpec: QuickSpec {
             }
 
             it("should set connection") {
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.connection) == "facebook"
             }
 
             it("should set scope") {
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.scope) == "openid"
             }
 
             it("should set connection scope for specified connection") {
                 options.connectionScope = ["facebook": "user_friends,email"]
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.parameters["connection_scope"]) == "user_friends,email"
             }
 
@@ -92,37 +92,37 @@ class Auth0OAuth2InteractorSpec: QuickSpec {
                 options.connectionScope = ["facebook": "user_friends,email",
                                            "google-oauth2": "gmail,ads"]
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.parameters["connection_scope"]) == "user_friends,email"
-                interactor.start("google-oauth2", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("google-oauth2", loginHint: nil, screenHint: nil,  useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.parameters["connection_scope"]) == "gmail,ads"
             }
 
             it("should not set audience if nil") {
                 options.audience = nil
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.audience).to(beNil())
             }
 
             it("should set audience") {
                 options.audience = "https://myapi.com/v1"
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.audience) == "https://myapi.com/v1"
             }
 
             it("should set leeway") {
                 options.leeway = 1000
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.leeway) == 1000
             }
 
             it("should set maxAge") {
                 options.maxAge = 1000
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.maxAge) == 1000
             }
 
@@ -130,32 +130,32 @@ class Auth0OAuth2InteractorSpec: QuickSpec {
                 let state = UUID().uuidString
                 options.parameters = ["state": state as Any]
                 interactor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: dispatcher, options: options, nativeHandlers: nativeHandlers)
-                interactor.start("facebook", loginHint: nil, screenHint: nil, callback: { _ in })
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                 expect(authentication.webAuth?.parameters["state"]) == state
             }
 
             it("should not yield error on success") {
                 authentication.webAuthResult = { return .success(result: mockCredentials()) }
-                interactor.start("facebook", loginHint: nil, screenHint: nil) { error = $0 }
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false) { error = $0 }
                 expect(error).toEventually(beNil())
             }
 
             it("should call credentials callback") {
                 let expected = mockCredentials()
                 authentication.webAuthResult = { return .success(result: expected) }
-                interactor.start("facebook", loginHint: nil, screenHint: nil) { error = $0 }
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false) { error = $0 }
                 expect(credentials).toEventually(equal(expected))
             }
 
             it("should handle cancel error") {
                 authentication.webAuthResult = { return .failure(error: WebAuthError.userCancelled) }
-                interactor.start("facebook", loginHint: nil, screenHint: nil) { error = $0 }
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false) { error = $0 }
                 expect(error).toEventually(equal(OAuth2AuthenticatableError.cancelled))
             }
 
             it("should handle generic error") {
                 authentication.webAuthResult = { return .failure(error: WebAuthError.noBundleIdentifierFound) }
-                interactor.start("facebook", loginHint: nil, screenHint: nil) { error = $0 }
+                interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false) { error = $0 }
                 expect(error).toEventually(equal(OAuth2AuthenticatableError.couldNotAuthenticate))
             }
 
@@ -176,7 +176,7 @@ class Auth0OAuth2InteractorSpec: QuickSpec {
             it("should yield no error on success") {
                 stub(condition: isOAuthAccessToken(domain) && hasAtLeast(["access_token": "SocialToken", "connection": "facebook"])) { _ in return Auth0Stubs.authentication() }.name = "Social Auth"
                 waitUntil(timeout: Timeout) { done in
-                    interactor.start("facebook", loginHint: nil, screenHint: nil) { error in
+                    interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false) { error in
                         expect(error).to(beNil())
                         done()
                     }
@@ -187,7 +187,7 @@ class Auth0OAuth2InteractorSpec: QuickSpec {
             it("should yield error on failure") {
                 stub(condition: isOAuthAccessToken(domain) && hasAtLeast(["access_token": "SocialToken", "connection": "facebook"])) { _ in return Auth0Stubs.failure() }.name = "Social Auth Fail"
                 waitUntil(timeout: Timeout) { done in
-                    interactor.start("facebook", loginHint: nil, screenHint: nil) { error in
+                    interactor.start("facebook", loginHint: nil, screenHint: nil, useEphemeralSession: false) { error in
                         expect(error).toNot(beNil())
                         done()
                     }
@@ -206,7 +206,7 @@ class Auth0OAuth2InteractorSpec: QuickSpec {
                 }
                 
                 it("should fallback to webAuth with connection") {
-                    interactor.start("twitter", loginHint: nil, screenHint: nil, callback: { _ in })
+                    interactor.start("twitter", loginHint: nil, screenHint: nil, useEphemeralSession: false, callback: { _ in })
                     expect(authentication.webAuth?.connection) == "twitter"
                 }
                 

--- a/LockTests/Interactors/DatabaseInteractorSpec.swift
+++ b/LockTests/Interactors/DatabaseInteractorSpec.swift
@@ -799,6 +799,7 @@ class DatabaseInteractorSpec: QuickSpec {
                         expect(webAuthentication.parameters["login_hint"]) == email
                         expect(webAuthentication.parameters["screen_hint"]) == "login"
                         expect(error) == .verificationFailure(error: OAuth2AuthenticatableError.couldNotAuthenticate)
+                        expect(webAuthentication.useEphemeralSession) == true
                         done()
                     }
                 }
@@ -1267,6 +1268,7 @@ class DatabaseInteractorSpec: QuickSpec {
                         expect(webAuthentication.parameters["login_hint"]) == email
                         expect(webAuthentication.parameters["screen_hint"]) == "signup"
                         expect(login) == .verificationFailure(error: OAuth2AuthenticatableError.couldNotAuthenticate)
+                        expect(webAuthentication.useEphemeralSession) == true
                         done()
                     }
                 }

--- a/LockTests/Utils/Mocks.swift
+++ b/LockTests/Utils/Mocks.swift
@@ -160,7 +160,7 @@ class MockMultifactorInteractor: MultifactorAuthenticatable {
 }
 
 class MockAuthInteractor: OAuth2Authenticatable {
-    func start(_ connection: String, loginHint: String? = nil, screenHint: String? = nil, callback: @escaping (OAuth2AuthenticatableError?) -> ()) {
+    func start(_ connection: String, loginHint: String? = nil, screenHint: String? = nil, useEphemeralSession: Bool = false, callback: @escaping (OAuth2AuthenticatableError?) -> ()) {
     }
 }
 
@@ -417,11 +417,13 @@ class MockOAuth2: OAuth2Authenticatable {
     var connection: String? = nil
     var onStart: () -> OAuth2AuthenticatableError? = { return nil }
     var parameters: [String: String] = [:]
+    var useEphemeralSession: Bool = false
 
-    func start(_ connection: String, loginHint: String? = nil, screenHint: String? = nil, callback: @escaping (OAuth2AuthenticatableError?) -> ()) {
+    func start(_ connection: String, loginHint: String? = nil, screenHint: String? = nil, useEphemeralSession: Bool = false, callback: @escaping (OAuth2AuthenticatableError?) -> ()) {
         self.connection = connection
         self.parameters["login_hint"] = loginHint
         self.parameters["screen_hint"] = screenHint
+        self.useEphemeralSession = useEphemeralSession
         callback(self.onStart())
     }
 


### PR DESCRIPTION
### Changes

This change makes the web session used during the bot detection CAPTCHA challenge ephemeral. This prevents issues where users are not able to complete the CAPTCHA challenge because the shared web session's credentials are too old, which makes the web session dismiss before the CAPTCHA is presented. Details and videos are in the linked support ticket and Lock.Android issue 

### References

- Auth0 support ticket https://support.auth0.com/tickets/00474936
- Lock.Android issue https://github.com/auth0/Lock.Android/issues/604

### Testing

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed