### PR TITLE
Terms and privacy button color customization

### DIFF
--- a/Lock/ClassicRouter.swift
+++ b/Lock/ClassicRouter.swift
@@ -53,7 +53,7 @@ struct ClassicRouter: Router {
             let authentication = self.lock.authentication
             let webAuthInteractor = Auth0OAuth2Interactor(authentication: authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
             let interactor = DatabaseInteractor(connection: database, authentication: authentication, webAuthentication: webAuthInteractor, user: self.user, options: self.lock.options, dispatcher: lock.observerStore)
-            let presenter = DatabasePresenter(interactor: interactor, connection: database, navigator: self, options: self.lock.options)
+            let presenter = DatabasePresenter(interactor: interactor, connection: database, navigator: self, options: self.lock.options, style: self.lock.style)
             if !oauth2.isEmpty {
                 let interactor = Auth0OAuth2Interactor(authentication: self.lock.authentication, dispatcher: lock.observerStore, options: self.lock.options, nativeHandlers: self.lock.nativeHandlers)
                 presenter.authPresenter = AuthPresenter(connections: oauth2, interactor: interactor, customStyle: self.lock.style.oauth2)

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -203,6 +203,7 @@ class DatabasePresenter: Presentable, Loggable {
             view?.allFields?.forEach { self.handleInput($0) }
             let interactor = self.creator
             button.inProgress = true
+
             interactor.create { createError, loginError in
                 Queue.main.async {
                     button.inProgress = false

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -27,6 +27,7 @@ class DatabasePresenter: Presentable, Loggable {
 
     let database: DatabaseConnection
     let options: Options
+    let style: Style
 
     var authenticator: DatabaseAuthenticatable
     var creator: DatabaseUserCreator
@@ -47,16 +48,17 @@ class DatabasePresenter: Presentable, Loggable {
     weak var databaseView: DatabaseOnlyView?
     var currentScreen: DatabaseScreen?
 
-    convenience init(interactor: DatabaseInteractor, connection: DatabaseConnection, navigator: Navigable, options: Options) {
-        self.init(authenticator: interactor, creator: interactor, connection: connection, navigator: navigator, options: options)
+    convenience init(interactor: DatabaseInteractor, connection: DatabaseConnection, navigator: Navigable, options: Options, style: Style) {
+        self.init(authenticator: interactor, creator: interactor, connection: connection, navigator: navigator, options: options, style: style)
     }
 
-    init(authenticator: DatabaseAuthenticatable, creator: DatabaseUserCreator, connection: DatabaseConnection, navigator: Navigable, options: Options) {
+    init(authenticator: DatabaseAuthenticatable, creator: DatabaseUserCreator, connection: DatabaseConnection, navigator: Navigable, options: Options, style: Style) {
         self.authenticator = authenticator
         self.creator = creator
         self.database = connection
         self.navigator = navigator
         self.options = options
+        self.style = style
     }
 
     var view: View {
@@ -249,7 +251,8 @@ class DatabasePresenter: Presentable, Loggable {
         }
         view.primaryButton?.onPress = checkTermsAndSignup
         view.secondaryButton?.title = "By signing up, you agree to our terms of\n service and privacy policy".i18n(key: "com.auth0.lock.database.button.tos", comment: "tos & privacy")
-        view.secondaryButton?.color = UIColor(red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0)
+        view.secondaryButton?.color = self.style.termsButtonColor
+        view.secondaryButton?.titleColor = self.style.termsButtonTitleColor
         view.secondaryButton?.onPress = { button in
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
             alert.popoverPresentationController?.sourceView = button

--- a/Lock/SecondaryButton.swift
+++ b/Lock/SecondaryButton.swift
@@ -43,6 +43,15 @@ class SecondaryButton: UIView {
         }
     }
 
+    var titleColor: UIColor? {
+        get {
+            return self.button?.currentTitleColor
+        }
+        set {
+            self.button?.setTitleColor(newValue, for: .normal)
+        }
+    }
+
     // MARK: - Initialisers
     convenience init() {
         self.init(frame: CGRect.zero)

--- a/Lock/Style.swift
+++ b/Lock/Style.swift
@@ -119,6 +119,12 @@ public struct Style {
         /// Secondary button color
     public var secondaryButtonColor = UIColor.black
 
+        /// Terms of Use and Privacy Policy button color
+    public var termsButtonColor = UIColor(red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0)
+
+        /// Terms of Use and Privacy Policy button title color
+    public var termsButtonTitleColor = UIColor.black
+
         /// Database login Tab Text Color
     public var tabTextColor = UIColor(red: 0.5725, green: 0.5804, blue: 0.5843, alpha: 1.0) // #929495
 

--- a/LockTests/Presenters/DatabasePresenterSpec.swift
+++ b/LockTests/Presenters/DatabasePresenterSpec.swift
@@ -51,7 +51,7 @@ class DatabasePresenterSpec: QuickSpec {
             messagePresenter = MockMessagePresenter()
             interactor = MockDBInteractor()
             navigator = MockNavigator()
-            presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+            presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
             presenter.messagePresenter = messagePresenter
             view = presenter.view as? DatabaseOnlyView
         }
@@ -163,7 +163,7 @@ class DatabasePresenterSpec: QuickSpec {
             it("should keep switcher when login and signup are allowed") {
                 var options = LockOptions()
                 options.allow = [.Login, .Signup]
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.switcher).toNot(beNil())
             }
@@ -171,7 +171,7 @@ class DatabasePresenterSpec: QuickSpec {
             it("should remove switcher when login or signup are not allowed") {
                 var options = LockOptions()
                 options.allow = [.Login]
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.switcher).to(beNil())
             }
@@ -179,7 +179,7 @@ class DatabasePresenterSpec: QuickSpec {
             it("should remove forgot button if it's not allowed") {
                 var options = LockOptions()
                 options.allow = [.Login]
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.secondaryButton).to(beNil())
             }
@@ -188,7 +188,7 @@ class DatabasePresenterSpec: QuickSpec {
                 var options = LockOptions()
                 options.allow = [.Login]
                 options.initialScreen = .login
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.form as? CredentialView).toNot(beNil())
             }
@@ -196,7 +196,7 @@ class DatabasePresenterSpec: QuickSpec {
             it("should show signup if login is not allowed") {
                 var options = LockOptions()
                 options.allow = [.Signup]
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.form as? SignUpView).toNot(beNil())
             }
@@ -205,7 +205,7 @@ class DatabasePresenterSpec: QuickSpec {
                 var options = LockOptions()
                 options.allow = [.Signup, .Login]
                 options.initialScreen = .signup
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.form as? SignUpView).toNot(beNil())
             }
@@ -213,7 +213,7 @@ class DatabasePresenterSpec: QuickSpec {
             it("should always show terms button in signup") {
                 var options = LockOptions()
                 options.allow = [.Signup]
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.secondaryButton).toNot(beNil())
             }
@@ -222,7 +222,7 @@ class DatabasePresenterSpec: QuickSpec {
                 var options = LockOptions()
                 options.allow = [.Signup]
                 options.showTerms = false
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.secondaryButton).to(beNil())
             }
@@ -232,7 +232,7 @@ class DatabasePresenterSpec: QuickSpec {
                 options.allow = [.Signup]
                 options.showTerms = false
                 options.mustAcceptTerms = true
-                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                 view = presenter.view as? DatabaseOnlyView
                 expect(view.secondaryButton).toNot(beNil())
             }
@@ -470,7 +470,7 @@ class DatabasePresenterSpec: QuickSpec {
                 it("should always show terms button in signup") {
                     var options = LockOptions()
                     options.autoClose = false
-                    presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                    presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                     presenter.messagePresenter = messagePresenter
                     view = presenter.view as? DatabaseOnlyView
                     interactor.onLogin = {
@@ -718,7 +718,7 @@ class DatabasePresenterSpec: QuickSpec {
 
                     beforeEach {
                         options.mustAcceptTerms = true
-                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: false), navigator: navigator, options: options)
+                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: false), navigator: navigator, options: options, style: .Auth0)
                         view = presenter.view as? DatabaseOnlyView
                         view.switcher?.selected = .signup
                         view.switcher?.onSelectionChange(view.switcher!)
@@ -754,7 +754,7 @@ class DatabasePresenterSpec: QuickSpec {
                     }
 
                     it("should switch to login on success") {
-                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                         view = presenter.view as? DatabaseOnlyView
 
                         let button = view.primaryButton!
@@ -767,7 +767,7 @@ class DatabasePresenterSpec: QuickSpec {
 
                     it("should remain on signup on success") {
                         options.allow = .Signup
-                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                         view = presenter.view as? DatabaseOnlyView
 
                         let button = view.primaryButton!
@@ -784,7 +784,7 @@ class DatabasePresenterSpec: QuickSpec {
                             options.loginAfterSignup = false
                             options.allow = [.Signup]
                             options.autoClose = false
-                            presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                            presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                             presenter.messagePresenter = messagePresenter
                             view = presenter.view as? DatabaseOnlyView
                         }
@@ -919,7 +919,7 @@ class DatabasePresenterSpec: QuickSpec {
                         connections = OfflineConnections()
                         connections.enterprise(name: "validAD", domains: ["valid.com"])
                         
-                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options)
+                        presenter = DatabasePresenter(authenticator: interactor, creator: interactor, connection: DatabaseConnection(name: connection, requiresUsername: true), navigator: navigator, options: options, style: .Auth0)
                         enterpriseInteractor = EnterpriseDomainInteractor(connections: connections, user: user, authentication: oauth2)
                         presenter.enterpriseInteractor = enterpriseInteractor
                         

--- a/LockTests/StyleSpec.swift
+++ b/LockTests/StyleSpec.swift
@@ -94,6 +94,14 @@ class StyleSpec: QuickSpec {
                 expect(style.secondaryButtonColor) == UIColor.black
             }
 
+            it("should have terms button color") {
+                expect(style.termsButtonColor) == UIColor(red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0)
+            }
+
+            it("should have terms title color") {
+                expect(style.termsButtonTitleColor) == UIColor.black
+            }
+
             it("should have database login tab text color") {
                 expect(style.tabTextColor) == UIColor(red: 0.5725, green: 0.5804, blue: 0.5843, alpha: 1.0)
             }


### PR DESCRIPTION
### Changes

Adds the ability to customize the background color of the button for terms of service and privacy policy.
Previously the color was hardcoded to `UIColor(red: 0.9333, green: 0.9333, blue: 0.9333, alpha: 1.0)` and could not be changed.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed