### PR TITLE
Enabled Xcode code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ commands:
             - vendor/bundle
       - run: |
           brew install swiftlint
-          grep -lR "shouldUseLaunchSchemeArgsEnv" *.* --null | xargs -0 sed -i '' -e 's/shouldUseLaunchSchemeArgsEnv = "YES"/shouldUseLaunchSchemeArgsEnv = "YES" codeCoverageEnabled = "YES"/g'
       - restore_cache:
           keys:
             - lock-swift-carthage-{ checksum "Cartfile.resolved" }}-<< parameters.xcode >>

--- a/Lock.xcodeproj/xcshareddata/xcschemes/Lock.xcscheme
+++ b/Lock.xcodeproj/xcshareddata/xcschemes/Lock.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
### Changes

Previously the code coverage generation was only enabled for CI builds. This PR enables it by default so that contributors can check the coverage without having to wait for a CI run.

### References

See https://github.com/auth0/Lock.swift/pull/649#issuecomment-781761006

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed