### PR TITLE
Fixed retain cycles on DatabasePresenter [SDK-2360]

### DIFF
--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -182,7 +182,7 @@ class DatabasePresenter: Presentable, Loggable {
         let form = view.form
         view.form?.onValueChange = self.handleInput
 
-        form?.onSubmit = { input in
+        form?.onSubmit = { [weak form] input in
             form?.onValueChange(input)
 
             guard let attribute = self.getUserAttribute(from: input.type) else { return false }

--- a/Lock/DatabasePresenter.swift
+++ b/Lock/DatabasePresenter.swift
@@ -100,7 +100,7 @@ class DatabasePresenter: Presentable, Loggable {
         let form = view.form
         form?.onValueChange = self.handleInput
 
-        form?.onSubmit = { input in
+        form?.onSubmit = { [weak form] input in
             form?.onValueChange(input)
 
             guard let attribute = self.getUserAttribute(from: input.type) else { return false }
@@ -114,7 +114,7 @@ class DatabasePresenter: Presentable, Loggable {
         }
 
         let action = { [weak form] (button: PrimaryButton) in
-            guard let isValid = view.form?.shouldSubmit(), isValid else { return }
+            guard let isValid = form?.shouldSubmit(), isValid else { return }
 
             self.messagePresenter?.hideCurrent()
             self.logger.info("Perform login for email: \(self.authenticator.email.verbatim())")
@@ -196,7 +196,7 @@ class DatabasePresenter: Presentable, Loggable {
         }
 
         let action = { [weak form, weak view] (button: PrimaryButton) in
-            guard let isValid = view?.form?.shouldSubmit(), isValid else { return }
+            guard let isValid = form?.shouldSubmit(), isValid else { return }
 
             self.messagePresenter?.hideCurrent()
             self.logger.info("Perform sign up for email \(self.creator.email.verbatim())")


### PR DESCRIPTION
### Changes

This PR fixes a couple of retain cycles causing memory leaks on `DatabasePresenter`.

<img width="634" alt="Screen Shot 2021-02-25 at 20 19 39" src="https://user-images.githubusercontent.com/5055789/109232384-08741080-77a7-11eb-8173-4a6f96b75e6f.png">

### References

Fixes https://github.com/auth0/Lock.swift/issues/653

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed