### PR TITLE
Release 2.22.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.0</string>
+	<string>2.22.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.22.1](https://github.com/auth0/Lock.swift/tree/2.22.1) (2021-04-13)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.0...2.22.1)
+
+**Fixed**
+- Fix LockViewController dismissal when presented as a popup [\#647](https://github.com/auth0/Lock.swift/pull/647) ([agirault](https://github.com/agirault))
+
 ## [2.22.0](https://github.com/auth0/Lock.swift/tree/2.22.0) (2021-03-09)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.21.0...2.22.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "Quick/Nimble" "v9.0.0"
 github "Quick/Quick" "v3.1.2"
-github "auth0/Auth0.swift" "1.31.0"
+github "auth0/Auth0.swift" "1.32.0"
 github "auth0/JWTDecode.swift" "2.6.0"
 github "auth0/SimpleKeychain" "0.12.2"
 github "emaloney/CleanroomLogger" "7.0.0"

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.0</string>
+	<string>2.22.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.0</string>
+	<string>2.22.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Utils/Mocks.swift
+++ b/LockTests/Utils/Mocks.swift
@@ -409,6 +409,14 @@ class MockWebAuth: WebAuth {
         self.maxAge = maxAge
         return self
     }
+    
+    func invitationURL(_ invitationURL: URL) -> Self {
+       return self
+   }
+       
+   func organization(_ organization: String) -> Self {
+       return self
+   }
 
     func clearSession(federated: Bool, callback: @escaping (Bool) -> Void) {
         callback(true)

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.0</string>
+	<string>2.22.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ coverage:
   range: "70...100"
   ignore:
     - Lock/OnePassword.swift
-    - LockTests/*
+    - LockTests/**/*
     - App/*
   status:
     patch:


### PR DESCRIPTION
**Fixed**
- Fix LockViewController dismissal when presented as a popup [\#647](https://github.com/auth0/Lock.swift/pull/647) ([agirault](https://github.com/agirault))