### PR TITLE
Use OTP grant for magic links [SDK-2576]

### DIFF
--- a/Lock/PasswordlessAuthTransaction.swift
+++ b/Lock/PasswordlessAuthTransaction.swift
@@ -42,8 +42,21 @@ struct PasswordlessLinkTransaction: PasswordlessAuthTransaction {
 extension PasswordlessAuthTransaction {
 
     func auth(withPasscode passcode: String, callback: @escaping (CredentialAuthError?) -> Void) {
-        CredentialAuth(oidc: self.options.oidcConformant, realm: connection, authentication: self.authentication)
-            .request(withIdentifier: identifier, password: passcode, options: self.options)
-            .start { self.handle(identifier: self.identifier, result: $0, callback: callback) }
+        var request: Request<Credentials, AuthenticationError>
+
+        if !options.oidcConformant {
+            request = CredentialAuth(oidc: self.options.oidcConformant,
+                                     realm: self.connection,
+                                     authentication: self.authentication)
+                .request(withIdentifier: self.identifier, password: passcode, options: self.options)
+        } else {
+            request = authentication.login(email: self.identifier,
+                                           code: passcode,
+                                           audience: self.options.audience,
+                                           scope: self.options.scope,
+                                           parameters: self.options.parameters)
+        }
+        request.start { self.handle(identifier: self.identifier, result: $0, callback: callback) }
     }
+
 }


### PR DESCRIPTION
### Changes

This PR uses the `http://auth0.com/oauth/grant-type/passwordless/otp` grant when performing passwordless login with magic links. It was previously using the deprecated `http://auth0.com/oauth/legacy/grant-type/ro` grant. It will still use that grant if the OIDC Conformant mode is not enabled.

### References

Fixes https://github.com/auth0/Lock.swift/issues/664

### Testing

This change has been tested manually using an iOS simulator.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed