### PR TITLE
Release 2.22.2

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.1</string>
+	<string>2.22.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.22.2](https://github.com/auth0/Lock.swift/tree/2.22.2) (2021-05-20)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.1...2.22.2)
+
+**Fixed**
+- Use OTP grant for magic links [SDK-2576] [\#667](https://github.com/auth0/Lock.swift/pull/667) ([Widcket](https://github.com/Widcket))
+
 ## [2.22.1](https://github.com/auth0/Lock.swift/tree/2.22.1) (2021-04-13)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.0...2.22.1)
 

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.1</string>
+	<string>2.22.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.1</string>
+	<string>2.22.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.1</string>
+	<string>2.22.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
**Fixed**
- Use OTP grant for magic links [SDK-2576] [\#667](https://github.com/auth0/Lock.swift/pull/667) ([Widcket](https://github.com/Widcket))