### PR TITLE
Make test dependencies not resolve when installing with SPM [SDK-2601]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,9 @@ let package = Package(
     ],
     dependencies: [
          .package(name: "Auth0", url: "https://github.com/auth0/Auth0.swift.git", .upToNextMajor(from: "1.31.0")),
-         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
-         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
-         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))
+         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
+         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Changes

Lock.swift relies on the [Quick](https://github.com/Quick/Quick) and [Nimble](https://github.com/Quick/Nimble) test libraries for its tests, and it's pinning their version range to a particular major. Currently, when installing Lock.swift with the Swift Package Manager it will resolve both test dependencies even though they're not used in the actual library. This opens up the possibility of conflict if the app the libraries are imported into is using another major version of Quick/Nimble.
SPM has, since swift 5.2 (released with Xcode 11.4), supported [a way](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md) to have the test dependencies not resolve if they're not used. Since we already dropped support for Xcode < 11.4, this will not be a breaking change.

### References

Fixes https://github.com/auth0/SimpleKeychain/issues/107
Related to https://github.com/auth0/SimpleKeychain/pull/108
Related to https://github.com/auth0/JWTDecode.swift/pull/125
Related to https://github.com/auth0/Auth0.swift/pull/476

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed