### PR TITLE
Release 2.22.3

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.2</string>
+	<string>2.22.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.22.3](https://github.com/auth0/Lock.swift/tree/2.22.3) (2021-06-07)
+[Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.2...2.22.3)
+
+
 ## [2.22.2](https://github.com/auth0/Lock.swift/tree/2.22.2) (2021-05-20)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.1...2.22.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [2.22.3](https://github.com/auth0/Lock.swift/tree/2.22.3) (2021-06-07)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.2...2.22.3)
 
+**Changed**
+- Make test dependencies not resolve when installing with SPM [SDK-2601] [\#671](https://github.com/auth0/Lock.swift/pull/671) ([Widcket](https://github.com/Widcket))
 
 ## [2.22.2](https://github.com/auth0/Lock.swift/tree/2.22.2) (2021-05-20)
 [Full Changelog](https://github.com/auth0/Lock.swift/compare/2.22.1...2.22.2)

--- a/Lock/Info.plist
+++ b/Lock/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.2</string>
+	<string>2.22.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.2</string>
+	<string>2.22.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.22.2</string>
+	<string>2.22.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
**Changed**
- Make test dependencies not resolve when installing with SPM [SDK-2601] [\#671](https://github.com/auth0/Lock.swift/pull/671) ([Widcket](https://github.com/Widcket))


[SDK-2601]: https://auth0team.atlassian.net/browse/SDK-2601