### PR TITLE
Expose onForgotPassword [SDK-2632]

### DIFF
--- a/Lock/Lock.swift
+++ b/Lock/Lock.swift
@@ -251,6 +251,19 @@ public class Lock: NSObject {
     }
 
     /**
+     Register a callback to be notified when a user requests a password reset.
+     The callback will yield the user identifier.
+
+     - parameter callback: called when a user requests a password reset.
+
+     - returns: Lock itself for chaining
+     */
+    public func onForgotPassword(callback: @escaping (String) -> Void) -> Lock {
+        self.observerStore.onForgotPassword = callback
+        return self
+    }
+
+    /**
      Presents Lock from the given controller
 
      - parameter controller: controller from where Lock is presented
@@ -277,7 +290,7 @@ public class Lock: NSObject {
         return self
     }
 
-        /// Lock's Bundle. Useful for getting bundled resources like images.
+    /// Lock's Bundle. Useful for getting bundled resources like images.
     public static var bundle: Bundle {
         return bundleForLock()
     }

--- a/LockTests/LockSpec.swift
+++ b/LockTests/LockSpec.swift
@@ -176,6 +176,14 @@ class LockSpec: QuickSpec {
                 expect(executed) == true
             }
 
+            it("should register onForgotPassword callback") {
+                var email: String? = nil
+                let callback: (String) -> () = { email = $0 }
+                let _ = lock.onForgotPassword(callback)
+                lock.observerStore.onForgotPassword("mail@mail.com")
+                expect(email) == "mail@mail.com"
+            }
+
             it("should register onPasswordless callback") {
                 var email: String? = nil
                 let callback: (String) -> () = { email = $0 }

--- a/LockTests/LockSpec.swift
+++ b/LockTests/LockSpec.swift
@@ -179,7 +179,7 @@ class LockSpec: QuickSpec {
             it("should register onForgotPassword callback") {
                 var email: String? = nil
                 let callback: (String) -> () = { email = $0 }
-                let _ = lock.onForgotPassword(callback)
+                let _ = lock.onForgotPassword(callback: callback)
                 lock.observerStore.onForgotPassword("mail@mail.com")
                 expect(email) == "mail@mail.com"
             }


### PR DESCRIPTION
### Changes

This PR exposes in the public API the `onForgotPassword` callback that was implemented and had unit tests, but could not be used as there was no public API for it.

#### Implementation
https://github.com/auth0/Lock.swift/blob/a13bb76bd1ef6d16716f19820d82a76e7fe2e9a4/Lock/ObserverStore.swift#L60

#### Unit tests
https://github.com/auth0/Lock.swift/blob/master/LockTests/Models/ObserverStoreSpec.swift#L79
https://github.com/auth0/Lock.swift/blob/master/LockTests/Models/ObserverStoreSpec.swift#L149
https://github.com/auth0/Lock.swift/blob/master/LockTests/Models/ObserverStoreSpec.swift#L154
https://github.com/auth0/Lock.swift/blob/master/LockTests/Models/ObserverStoreSpec.swift#L163

https://user-images.githubusercontent.com/5055789/124201591-dead5c00-daae-11eb-920b-16468ea6cebc.mov

### References

Fixes #666 

Lock.Android exposes a `RESET_PASSWORD` event: https://github.com/auth0/Lock.Android/blob/main/lib/src/main/java/com/auth0/android/lock/LockCallback.java#L56

### Testing

The callback has unit tests, but it was also tested manually using an iPhone simulator. A unit test covering the new public API method was also added.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed