### PR TITLE
Use the new release automation solution

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,8 @@
+{
+    "files": {
+        "Lock/Info.plist": [],
+        "README.md": ["~> {MAJOR}.{MINOR}"]
+    },
+    "postbump": "bundle update",
+    "prefixVersion": false
+}

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.23.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/LockTests/Info.plist
+++ b/LockTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.23.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/LockUITests/Info.plist
+++ b/LockUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.23.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,14 +87,7 @@ platform :ios do
     ENV["FASTLANE_HIDE_TIMESTAMP"] = "false"
   end
 
-  desc "Prepares the library for release by updating versions and creating release pull request"
-  desc "You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]"
-  lane :release_prepare do |options|
-    release_options = {repository: 'Lock.swift', xcodeproj: 'Lock.xcodeproj', target: 'Lock.iOS'}.merge(options)
-    prepare_release release_options
-  end
-
-  desc "Performs the prepared release by creating a tag and pusing to remote"
+  desc "Performs the prepared release by creating a tag and pushing to remote"
   lane :release_perform do
     perform_release target: 'Lock.iOS'
   end


### PR DESCRIPTION
### Changes

This PR adds support for the new release automation CLI.

Previously, we were using a [custom Fastlane plugin](https://github.com/auth0/fastlane-plugin-auth0_shipper) for bumping the version number and updating the Changelog. To bump the version, that plugin [uses](https://github.com/auth0/fastlane-plugin-auth0_shipper/blob/master/lib/fastlane/plugin/auth0_shipper/actions/prepare_release_action.rb#L24) the `IncrementVersionNumberAction` action from Fastlane. That action [uses](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/increment_version_number.rb#L71) the `agvtool new-marketing-version` command to bump the version number. That command will bump the version number in every `Info.plist` file it can find, regardless of whether it's actually necessary or not:

<img width="645" alt="Screen Shot 2021-08-23 at 17 51 31" src="https://user-images.githubusercontent.com/5055789/130521569-f0dd8ba6-1766-4c53-a892-93ec7596974f.png">

See [a previous release](https://github.com/auth0/Lock.swift/pull/675/files) of this SDK:
 
<img width="780" alt="Screen Shot 2021-08-23 at 17 58 16" src="https://user-images.githubusercontent.com/5055789/130521608-b07ccb7a-a98a-4652-a8e7-f78ee41013dd.png">

It's bumping the version number of the **test app** and the **test targets**; only the **library target's** version number needs to be bumped (`Lock/Info.plist`).

So this PR sets up the version number replacement for `Lock/Info.plist` in the `.shiprc` file, and sets the version number of the test app and the test targets to be `0.1.0`. That means that going forward, each release PR will only be bumping the version number in `Lock/Info.plist`.

Additionally, this PR removes the now-unused Fastlane task.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors