### PR TITLE
Remove agvtool from podspec

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,7 @@
 {
     "files": {
         "Lock/Info.plist": [],
+        "Lock.podspec": [],
         "README.md": ["~> {MAJOR}.{MINOR}"]
     },
     "postbump": "bundle update",

--- a/Lock.podspec
+++ b/Lock.podspec
@@ -1,7 +1,6 @@
-version = `agvtool mvers -terse1`.strip
 Pod::Spec.new do |s|
   s.name             = "Lock"
-  s.version          = version
+  s.version          = '2.23.0'
   s.summary          = "A library that uses Auth0 for Authentication with Native Look & Feel"
   s.description      = <<-DESC
 [![Auth0](https://i.cloudup.com/1vaSVATKTL.png)](http://auth0.com)
@@ -26,6 +25,6 @@ Auth0 is a SaaS that helps you with Authentication and Authorization. You can us
     classic.ios.resource = ["Lock/*.xcassets", "Lock/*.lproj", "Lock/passwordless_country_codes.plist"]
   end
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3']
+  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
 
 end


### PR DESCRIPTION
### Changes

The podspec relied on `agvtool` to get the current version number. That tool looks up the relevant key in every `Info.plist` file it can find:

<img width="652" alt="Screen Shot 2021-09-01 at 23 49 16" src="https://user-images.githubusercontent.com/5055789/131773660-490ca611-d7b6-458f-a374-b19d34c06725.png">

Since we're not bumping the version number in every target anymore, just on the library target, `agvtool` was not finding the correct version number. So this PR does away with `agvtool` and just uses the release CLI to bump the version number in the podspec. 

### References

Related to https://github.com/auth0/Lock.swift/pull/677

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed