### PR TITLE
Use tenant.locality.auth0.com as CDN URL [SDK-2709]

### DIFF
--- a/Lock/CDNLoaderInteractor.swift
+++ b/Lock/CDNLoaderInteractor.swift
@@ -30,7 +30,7 @@ struct CDNLoaderInteractor: RemoteConnectionLoader, Loggable {
     let url: URL
 
     init(baseURL: URL, clientId: String) {
-        self.url = URL(string: "client/\(clientId).js", relativeTo: cdnURL(from: baseURL))!
+        self.url = URL(string: "client/\(clientId).js", relativeTo: baseURL)!
     }
 
     func load(_ callback: @escaping (UnrecoverableError?, Connections?) -> Void) {
@@ -230,12 +230,4 @@ private struct ConnectionInfo {
         self.json = json
         self.name = name
     }
-}
-
-private func cdnURL(from url: URL) -> URL {
-    guard let host = url.host, host.hasSuffix(".auth0.com") else { return url }
-    let components = host.components(separatedBy: ".")
-    guard components.count == 4 else { return URL(string: "https://cdn.auth0.com")! }
-    let region = components[1]
-    return URL(string: "https://cdn.\(region).auth0.com")!
 }

--- a/LockTests/Interactors/CDNLoaderInteractorSpec.swift
+++ b/LockTests/Interactors/CDNLoaderInteractorSpec.swift
@@ -40,24 +40,9 @@ class CDNLoaderInteractorSpec: QuickSpec {
 
         describe("init") {
 
-            it("should build url from non-auth0 domain") {
-                let loader = CDNLoaderInteractor(baseURL: URL(string: "https://somewhere.far.beyond")!, clientId: clientId)
-                expect(loader.url.absoluteString) == "https://somewhere.far.beyond/client/\(clientId).js"
-            }
-
-            it("should build url from auth0 domain") {
+            it("should use the base url to load strategies") {
                 let loader = CDNLoaderInteractor(baseURL: URL(string: "https://samples.auth0.com")!, clientId: clientId)
-                expect(loader.url.absoluteString) == "https://cdn.auth0.com/client/\(clientId).js"
-            }
-
-            it("should build url from auth0 domain for eu region") {
-                let loader = CDNLoaderInteractor(baseURL: URL(string: "https://samples.eu.auth0.com")!, clientId: clientId)
-                expect(loader.url.absoluteString) == "https://cdn.eu.auth0.com/client/\(clientId).js"
-            }
-
-            it("should build url from auth0 domain for au region") {
-                let loader = CDNLoaderInteractor(baseURL: URL(string: "https://samples.au.auth0.com")!, clientId: clientId)
-                expect(loader.url.absoluteString) == "https://cdn.au.auth0.com/client/\(clientId).js"
+                expect(loader.url.absoluteString) == "https://samples.auth0.com/client/\(clientId).js"
             }
 
         }

--- a/LockTests/Utils/NetworkStub.swift
+++ b/LockTests/Utils/NetworkStub.swift
@@ -148,7 +148,7 @@ func isOAuthAccessToken(_ domain: String) -> HTTPStubsTestBlock {
 }
 
 func isCDN(forClientId clientId: String) -> HTTPStubsTestBlock {
-    return isMethodGET() && isHost("cdn.auth0.com") && isPath("/client/\(clientId).js")
+    return isMethodGET() && isHost("overmind.auth0.com") && isPath("/client/\(clientId).js")
 }
 
 // MARK: - Response Stubs


### PR DESCRIPTION
### Changes

This PR replaces the CDN URL from `cdn.locality.auth0.com` to `tenant.locality.auth0.com`.

### Testing

Besides a unit test, this change was tested manually:

<img width="870" alt="Screen Shot 2021-09-17 at 18 48 45" src="https://user-images.githubusercontent.com/5055789/133858251-f4b90d1d-ebd4-41ce-8aa3-bb33c694ee91.png">

https://user-images.githubusercontent.com/5055789/133858269-9cea8cd5-3f36-4dc9-b2a7-e048a5781a3d.mov

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed