### PR TITLE
Migrate to XCFrameworks [SDK-2804]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ commands:
             - << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install gems
-          command: |
-            bundle check || bundle install --without=development
+          command: bundle check || bundle install --without=development
       - save_cache:
           key: << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 
 executors:
-  job-environment:
+  macos-executor:
+    parameters:
+      xcode:
+        type: string
     shell: /bin/bash --login -eo pipefail
+    macos:
+      xcode: << parameters.xcode >>
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
@@ -19,63 +24,77 @@ executors:
 commands:
   prepare:
     parameters:
-      ruby:
+      scheme:
         type: string
-        default: "2.7.1p83"
-      xcode:
-        type: string
-        default: "11.7.0"
     steps:
       - restore_cache:
           keys:
-          - lock-swift-gems-{{ checksum "Gemfile.lock" }}
-          - lock-swift-gems-
-      - run: |
-          echo "ruby-<< parameters.ruby >>" > ~/.ruby-version
-          bundle check || bundle install --without=development
+            - << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install gems
+          command: |
+            bundle check || bundle install --without=development
       - save_cache:
-          key: lock-swift-gems-{{ checksum "Gemfile.lock" }}
+          key: << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: |
-          brew install swiftlint
+      - run:
+          name: Install Swiftlint
+          command: brew install swiftlint
+      - run:
+          name: Save Xcode version
+          command: xcodebuild -version | tee .xcode-version
       - restore_cache:
           keys:
-            - lock-swift-carthage-{ checksum "Cartfile.resolved" }}-<< parameters.xcode >>
-            - lock-swift-carthage-{ checksum "Cartfile.resolved" }}
-            - lock-swift-carthage-
-      - run: bundle exec fastlane ios bootstrap
+            - << parameters.scheme >>-v1-carthage-{{ checksum "Cartfile.resolved" }}-{{ checksum ".xcode-version" }}
+      - run:
+          name: Install dependencies
+          command: carthage bootstrap --use-xcframeworks --no-use-binaries --cache-builds --platform iOS
       - save_cache:
-          key: lock-swift-carthage-{ checksum "Cartfile.resolved" }}-<< parameters.xcode >>
+          key: << parameters.scheme >>-v1-carthage-{{ checksum "Cartfile.resolved" }}-{{ checksum ".xcode-version" }}
           paths:
             - Carthage/Build
-  test:
-    steps: 
-      - run: bundle exec fastlane ios ci
-  pod-lint:
+  test-ios:
+    parameters:
+      scheme:
+        type: string
     steps:
-      - run: bundle exec fastlane ios pod_lint
-  send-coverage-report:
-    steps:
-      - run: bash <(curl -s https://codecov.io/bash) -J 'Lock'
-
-jobs:
-  build-and-test-swift-5_2:
-    executor: job-environment
-    macos:
-      xcode: 11.7.0
-    steps:
-      - checkout
-      - prepare
-      - test
-      - send-coverage-report
-      - pod-lint
+      - run:
+          name: Run iOS tests
+          command: bundle exec fastlane ios ci
+      - run:
+          name: Upload coverage report
+          command: bash <(curl -s https://codecov.io/bash) -J '<< parameters.scheme >>'
+      - run:
+          name: Run pod lib lint
+          command: bundle exec fastlane ios pod_lint
       - store_test_results:
           path: output/scan
       - store_artifacts:
           path: output
 
+jobs:
+  build-and-test:
+    parameters:
+      xcode:
+        type: string
+      scheme:
+        type: string
+    executor:
+      name: macos-executor
+      xcode: << parameters.xcode >>
+    steps:
+      - checkout
+      - prepare:
+          scheme: << parameters.scheme >>
+      - test-ios:
+          scheme: << parameters.scheme >>
+
 workflows:
   build:
     jobs:
-      -  build-and-test-swift-5_2
+      - build-and-test:
+          scheme: "Lock"
+          matrix:
+            parameters:
+              xcode: ["13.0.0", "12.5.1"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'fastlane', '>= 2.127.2'
-gem "cocoapods", ">= 1.8.4"
+gem 'fastlane'
+gem "cocoapods"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval(File.read(plugins_path), binding) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,8 +276,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (>= 1.8.4)
-  fastlane (>= 2.127.2)
+  cocoapods
+  fastlane
   fastlane-plugin-auth0_shipper
 
 BUNDLED WITH

--- a/Lock.podspec
+++ b/Lock.podspec
@@ -25,6 +25,6 @@ Auth0 is a SaaS that helps you with Authentication and Authorization. You can us
     classic.ios.resource = ["Lock/*.xcassets", "Lock/*.lproj", "Lock/passwordless_country_codes.plist"]
   end
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
+  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
 
 end

--- a/Lock.xcodeproj/project.pbxproj
+++ b/Lock.xcodeproj/project.pbxproj
@@ -78,7 +78,6 @@
 		5C53A8112703F4E100A7C0A3 /* JWTDecode.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C53A8122703F4E100A7C0A3 /* SimpleKeychain.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */; };
 		5C53A8132703F4E100A7C0A3 /* SimpleKeychain.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5C53A8142703F4FF00A7C0A3 /* Auth0.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */; };
 		5F0FCF901E20117E00E3D53B /* ObserverStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0FCF8F1E20117E00E3D53B /* ObserverStore.swift */; };
 		5F0FCF921E201CF300E3D53B /* ObserverStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0FCF911E201CF300E3D53B /* ObserverStoreSpec.swift */; };
 		5F14565A1D5130E80085DF9C /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1456591D5130E80085DF9C /* Colors.swift */; };
@@ -174,7 +173,6 @@
 		5FEADD011D1A7EBC0032D810 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5FEADCFF1D1A7EBC0032D810 /* LaunchScreen.storyboard */; };
 		5FEADD071D1A7EFC0032D810 /* Lock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FEAE1C61D1A5154005C0028 /* Lock.framework */; };
 		5FEAE1CA1D1A5154005C0028 /* Lock.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FEAE1C91D1A5154005C0028 /* Lock.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5FEAE1D11D1A5154005C0028 /* Lock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FEAE1C61D1A5154005C0028 /* Lock.framework */; };
 		5FEAE2101D1A5691005C0028 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEAE20F1D1A5691005C0028 /* HeaderView.swift */; };
 		5FEEE8181DB6AC8E00B4DFED /* Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEEE8171DB6AC8E00B4DFED /* Rule.swift */; };
 		5FEEE81A1DB6AF3800B4DFED /* RuleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEEE8191DB6AF3800B4DFED /* RuleSpec.swift */; };
@@ -453,7 +451,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5C53A8142703F4FF00A7C0A3 /* Auth0.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -464,7 +461,6 @@
 				5C53A7FA2703F48100A7C0A3 /* Quick.xcframework in Frameworks */,
 				5C53A7FB2703F48100A7C0A3 /* Nimble.xcframework in Frameworks */,
 				5C53A7FC2703F48100A7C0A3 /* OHHTTPStubs.xcframework in Frameworks */,
-				5FEAE1D11D1A5154005C0028 /* Lock.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Lock.xcodeproj/project.pbxproj
+++ b/Lock.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -28,7 +28,6 @@
 		5B3874D41E97C13D00244326 /* CountryCodesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3874D01E97C11000244326 /* CountryCodesSpec.swift */; };
 		5B3874D51E97C14000244326 /* PolicyViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3874D21E97C11E00244326 /* PolicyViewSpec.swift */; };
 		5B3DA2551E6EB9F800370C17 /* CountryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3DA2541E6EB9F800370C17 /* CountryTableViewController.swift */; };
-		5B416D961EE7475B009BA5BD /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B416D951EE7475B009BA5BD /* SimpleKeychain.framework */; };
 		5B4BA3EB1E8000100067FC3F /* Auth0OAuth2InteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F92C68A1D4FE90F00CCE6C0 /* Auth0OAuth2InteractorSpec.swift */; };
 		5B4BA3EC1E8000170067FC3F /* EnterpriseDomainInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6631511DDB990B001CB043 /* EnterpriseDomainInteractorSpec.swift */; };
 		5B4DE0151DD66DE1004C8AC2 /* EnterpriseDomainInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4DE0141DD66DE1004C8AC2 /* EnterpriseDomainInteractor.swift */; };
@@ -65,7 +64,21 @@
 		5BE978241E8405C70090EC07 /* PasswordlessAuthTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE978231E8405C70090EC07 /* PasswordlessAuthTransaction.swift */; };
 		5BEDE14A1EC0A9F10007300D /* LockUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1441EC0A9EB0007300D /* LockUITests.swift */; };
 		5BEDE14C1EC0A9F10007300D /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1461EC0A9EB0007300D /* SnapshotHelper.swift */; };
-		5C49EB2E23EB138C008D562F /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C49EB2D23EB138C008D562F /* JWTDecode.framework */; };
+		5C53A7FA2703F48100A7C0A3 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A7F72703F48100A7C0A3 /* Quick.xcframework */; };
+		5C53A7FB2703F48100A7C0A3 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A7F82703F48100A7C0A3 /* Nimble.xcframework */; };
+		5C53A7FC2703F48100A7C0A3 /* OHHTTPStubs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A7F92703F48100A7C0A3 /* OHHTTPStubs.xcframework */; };
+		5C53A7FD2703F48C00A7C0A3 /* Nimble.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A7F82703F48100A7C0A3 /* Nimble.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A7FE2703F48C00A7C0A3 /* OHHTTPStubs.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A7F92703F48100A7C0A3 /* OHHTTPStubs.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A7FF2703F48C00A7C0A3 /* Quick.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A7F72703F48100A7C0A3 /* Quick.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A80C2703F4E100A7C0A3 /* Auth0.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */; };
+		5C53A80D2703F4E100A7C0A3 /* Auth0.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A80E2703F4E100A7C0A3 /* CleanroomLogger.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8012703F4AB00A7C0A3 /* CleanroomLogger.xcframework */; };
+		5C53A80F2703F4E100A7C0A3 /* CleanroomLogger.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A8012703F4AB00A7C0A3 /* CleanroomLogger.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A8102703F4E100A7C0A3 /* JWTDecode.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */; };
+		5C53A8112703F4E100A7C0A3 /* JWTDecode.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A8122703F4E100A7C0A3 /* SimpleKeychain.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */; };
+		5C53A8132703F4E100A7C0A3 /* SimpleKeychain.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C53A8142703F4FF00A7C0A3 /* Auth0.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */; };
 		5F0FCF901E20117E00E3D53B /* ObserverStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0FCF8F1E20117E00E3D53B /* ObserverStore.swift */; };
 		5F0FCF921E201CF300E3D53B /* ObserverStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0FCF911E201CF300E3D53B /* ObserverStoreSpec.swift */; };
 		5F14565A1D5130E80085DF9C /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1456591D5130E80085DF9C /* Colors.swift */; };
@@ -83,13 +96,9 @@
 		5F2496BC1D665AF700A1C6E2 /* DatabaseUserCreatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2496BB1D665AF700A1C6E2 /* DatabaseUserCreatorError.swift */; };
 		5F2496BE1D67ADB300A1C6E2 /* EmailValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2496BD1D67ADB300A1C6E2 /* EmailValidatorSpec.swift */; };
 		5F390E871D638A6D00FC549C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F390E861D638A6D00FC549C /* Logger.swift */; };
-		5F390E8A1D63A5B800FC549C /* CleanroomLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F390E881D63A5B800FC549C /* CleanroomLogger.framework */; };
 		5F390E8D1D63B99300FC549C /* LoggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F390E8C1D63B99300FC549C /* LoggerSpec.swift */; };
 		5F508FF71D1D868900EAA650 /* DatabaseInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F508FF61D1D868900EAA650 /* DatabaseInteractor.swift */; };
 		5F508FFB1D1DB1E700EAA650 /* DatabaseInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F508FF91D1DB1C200EAA650 /* DatabaseInteractorSpec.swift */; };
-		5F5090031D1DE78800EAA650 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F814FD01D1A7294003670A4 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5F5090041D1DE78800EAA650 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F814FD11D1A7294003670A4 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5F5090051D1DE78800EAA650 /* OHHTTPStubs.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F814FD31D1A7294003670A4 /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5F5090081D1DE7BA00EAA650 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5090071D1DE7BA00EAA650 /* NetworkStub.swift */; };
 		5F50900A1D1DEE9A00EAA650 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5090091D1DEE9A00EAA650 /* Constants.swift */; };
 		5F50900E1D1DF40400EAA650 /* DatabaseOnlyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50900D1D1DF40400EAA650 /* DatabaseOnlyView.swift */; };
@@ -119,12 +128,8 @@
 		5F73CDDA1D30957900D8D8D1 /* DatabasePasswordInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F73CDD91D30957900D8D8D1 /* DatabasePasswordInteractor.swift */; };
 		5F73CDDC1D309BE900D8D8D1 /* DatabasePasswordInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F73CDDB1D309BE900D8D8D1 /* DatabasePasswordInteractorSpec.swift */; };
 		5F73CDDE1D30B16900D8D8D1 /* DatabaseForgotPasswordPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F73CDDD1D30B16900D8D8D1 /* DatabaseForgotPasswordPresenterSpec.swift */; };
-		5F814FD51D1A72A6003670A4 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F814FD01D1A7294003670A4 /* Quick.framework */; };
-		5F814FD61D1A72A6003670A4 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F814FD11D1A7294003670A4 /* Nimble.framework */; };
-		5F814FD71D1A72A6003670A4 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F814FD31D1A7294003670A4 /* OHHTTPStubs.framework */; };
 		5F9231D51D5B6C5E00D92580 /* AuthCollectionViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9231D41D5B6C5E00D92580 /* AuthCollectionViewSpec.swift */; };
 		5F92C68D1D50E47100CCE6C0 /* AuthStyleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F92C68C1D50E47100CCE6C0 /* AuthStyleSpec.swift */; };
-		5F99AA761D1A7FA100D27842 /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F814FD21D1A7294003670A4 /* Auth0.framework */; };
 		5F99AA7A1D1B031500D27842 /* Lock.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F99AA791D1B031500D27842 /* Lock.xcassets */; };
 		5F99AA821D1B0A3900D27842 /* i18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F99AA811D1B0A3900D27842 /* i18n.swift */; };
 		5F99AA841D1B0BCE00D27842 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F99AA831D1B0BCE00D27842 /* Lock.swift */; };
@@ -162,7 +167,6 @@
 		5FE50DBD1D79B8AD00D82290 /* CDNLoaderInteractorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE50DBC1D79B8AD00D82290 /* CDNLoaderInteractorSpec.swift */; };
 		5FE50DBF1D7A254000D82290 /* ConnectionLoadingPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE50DBE1D7A254000D82290 /* ConnectionLoadingPresenterSpec.swift */; };
 		5FE50DC11D7DED8C00D82290 /* OfflineConnectionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE50DC01D7DED8C00D82290 /* OfflineConnectionsSpec.swift */; };
-		5FEADCEF1D1A76610032D810 /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F814FD21D1A7294003670A4 /* Auth0.framework */; };
 		5FEADCF71D1A7EBC0032D810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEADCF61D1A7EBC0032D810 /* AppDelegate.swift */; };
 		5FEADCF91D1A7EBC0032D810 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEADCF81D1A7EBC0032D810 /* ViewController.swift */; };
 		5FEADCFC1D1A7EBC0032D810 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5FEADCFA1D1A7EBC0032D810 /* Main.storyboard */; };
@@ -221,9 +225,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				5F5090031D1DE78800EAA650 /* Quick.framework in CopyFiles */,
-				5F5090041D1DE78800EAA650 /* Nimble.framework in CopyFiles */,
-				5F5090051D1DE78800EAA650 /* OHHTTPStubs.framework in CopyFiles */,
+				5C53A7FD2703F48C00A7C0A3 /* Nimble.xcframework in CopyFiles */,
+				5C53A7FE2703F48C00A7C0A3 /* OHHTTPStubs.xcframework in CopyFiles */,
+				5C53A7FF2703F48C00A7C0A3 /* Quick.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,6 +237,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				5C53A80F2703F4E100A7C0A3 /* CleanroomLogger.xcframework in CopyFiles */,
+				5C53A8112703F4E100A7C0A3 /* JWTDecode.xcframework in CopyFiles */,
+				5C53A8132703F4E100A7C0A3 /* SimpleKeychain.xcframework in CopyFiles */,
+				5C53A80D2703F4E100A7C0A3 /* Auth0.xcframework in CopyFiles */,
 				5F99AA8E1D1B4BFA00D27842 /* Lock.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -261,7 +269,6 @@
 		5B3874D01E97C11000244326 /* CountryCodesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryCodesSpec.swift; sourceTree = "<group>"; };
 		5B3874D21E97C11E00244326 /* PolicyViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PolicyViewSpec.swift; sourceTree = "<group>"; };
 		5B3DA2541E6EB9F800370C17 /* CountryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryTableViewController.swift; sourceTree = "<group>"; };
-		5B416D951EE7475B009BA5BD /* SimpleKeychain.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SimpleKeychain.framework; path = Carthage/Build/iOS/SimpleKeychain.framework; sourceTree = "<group>"; };
 		5B4DE0141DD66DE1004C8AC2 /* EnterpriseDomainInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnterpriseDomainInteractor.swift; path = Lock/EnterpriseDomainInteractor.swift; sourceTree = SOURCE_ROOT; };
 		5B4DE0161DD67064004C8AC2 /* EnterpriseActiveAuthPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnterpriseActiveAuthPresenter.swift; path = Lock/EnterpriseActiveAuthPresenter.swift; sourceTree = SOURCE_ROOT; };
 		5B4DE0181DD670F7004C8AC2 /* EnterpriseActiveAuthView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnterpriseActiveAuthView.swift; path = Lock/EnterpriseActiveAuthView.swift; sourceTree = SOURCE_ROOT; };
@@ -302,7 +309,13 @@
 		5BEDE13E1EC0A9750007300D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5BEDE1441EC0A9EB0007300D /* LockUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockUITests.swift; sourceTree = "<group>"; };
 		5BEDE1461EC0A9EB0007300D /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
-		5C49EB2D23EB138C008D562F /* JWTDecode.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JWTDecode.framework; path = Carthage/Build/iOS/JWTDecode.framework; sourceTree = "<group>"; };
+		5C53A7F72703F48100A7C0A3 /* Quick.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Quick.xcframework; path = Carthage/Build/Quick.xcframework; sourceTree = "<group>"; };
+		5C53A7F82703F48100A7C0A3 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
+		5C53A7F92703F48100A7C0A3 /* OHHTTPStubs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OHHTTPStubs.xcframework; path = Carthage/Build/OHHTTPStubs.xcframework; sourceTree = "<group>"; };
+		5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SimpleKeychain.xcframework; path = Carthage/Build/SimpleKeychain.xcframework; sourceTree = "<group>"; };
+		5C53A8012703F4AB00A7C0A3 /* CleanroomLogger.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CleanroomLogger.xcframework; path = Carthage/Build/CleanroomLogger.xcframework; sourceTree = "<group>"; };
+		5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = JWTDecode.xcframework; path = Carthage/Build/JWTDecode.xcframework; sourceTree = "<group>"; };
+		5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Auth0.xcframework; path = Carthage/Build/Auth0.xcframework; sourceTree = "<group>"; };
 		5F0FCF8F1E20117E00E3D53B /* ObserverStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverStore.swift; sourceTree = "<group>"; };
 		5F0FCF911E201CF300E3D53B /* ObserverStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ObserverStoreSpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5F1456591D5130E80085DF9C /* Colors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Lock/Colors.swift; sourceTree = SOURCE_ROOT; };
@@ -320,8 +333,6 @@
 		5F2496BB1D665AF700A1C6E2 /* DatabaseUserCreatorError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DatabaseUserCreatorError.swift; path = Lock/DatabaseUserCreatorError.swift; sourceTree = SOURCE_ROOT; };
 		5F2496BD1D67ADB300A1C6E2 /* EmailValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailValidatorSpec.swift; sourceTree = "<group>"; };
 		5F390E861D638A6D00FC549C /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Logger.swift; path = Lock/Logger.swift; sourceTree = SOURCE_ROOT; };
-		5F390E881D63A5B800FC549C /* CleanroomLogger.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CleanroomLogger.framework; path = Carthage/Build/iOS/CleanroomLogger.framework; sourceTree = "<group>"; };
-		5F390E891D63A5B800FC549C /* CleanroomASL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CleanroomASL.framework; path = Carthage/Build/iOS/CleanroomASL.framework; sourceTree = "<group>"; };
 		5F390E8C1D63B99300FC549C /* LoggerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerSpec.swift; sourceTree = "<group>"; };
 		5F508FF61D1D868900EAA650 /* DatabaseInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DatabaseInteractor.swift; path = Lock/DatabaseInteractor.swift; sourceTree = SOURCE_ROOT; };
 		5F508FF91D1DB1C200EAA650 /* DatabaseInteractorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseInteractorSpec.swift; sourceTree = "<group>"; };
@@ -354,10 +365,6 @@
 		5F73CDD91D30957900D8D8D1 /* DatabasePasswordInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DatabasePasswordInteractor.swift; path = Lock/DatabasePasswordInteractor.swift; sourceTree = SOURCE_ROOT; };
 		5F73CDDB1D309BE900D8D8D1 /* DatabasePasswordInteractorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabasePasswordInteractorSpec.swift; sourceTree = "<group>"; };
 		5F73CDDD1D30B16900D8D8D1 /* DatabaseForgotPasswordPresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseForgotPasswordPresenterSpec.swift; sourceTree = "<group>"; };
-		5F814FD01D1A7294003670A4 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
-		5F814FD11D1A7294003670A4 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		5F814FD21D1A7294003670A4 /* Auth0.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Auth0.framework; path = Carthage/Build/iOS/Auth0.framework; sourceTree = "<group>"; };
-		5F814FD31D1A7294003670A4 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		5F9231D41D5B6C5E00D92580 /* AuthCollectionViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthCollectionViewSpec.swift; sourceTree = "<group>"; };
 		5F92C68A1D4FE90F00CCE6C0 /* Auth0OAuth2InteractorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Auth0OAuth2InteractorSpec.swift; sourceTree = "<group>"; };
 		5F92C68C1D50E47100CCE6C0 /* AuthStyleSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthStyleSpec.swift; sourceTree = "<group>"; };
@@ -434,10 +441,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5C49EB2E23EB138C008D562F /* JWTDecode.framework in Frameworks */,
-				5B416D961EE7475B009BA5BD /* SimpleKeychain.framework in Frameworks */,
-				5F390E8A1D63A5B800FC549C /* CleanroomLogger.framework in Frameworks */,
-				5F99AA761D1A7FA100D27842 /* Auth0.framework in Frameworks */,
+				5C53A80E2703F4E100A7C0A3 /* CleanroomLogger.xcframework in Frameworks */,
+				5C53A8102703F4E100A7C0A3 /* JWTDecode.xcframework in Frameworks */,
+				5C53A8122703F4E100A7C0A3 /* SimpleKeychain.xcframework in Frameworks */,
+				5C53A80C2703F4E100A7C0A3 /* Auth0.xcframework in Frameworks */,
 				5FEADD071D1A7EFC0032D810 /* Lock.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -446,7 +453,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FEADCEF1D1A76610032D810 /* Auth0.framework in Frameworks */,
+				5C53A8142703F4FF00A7C0A3 /* Auth0.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -454,9 +461,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5F814FD61D1A72A6003670A4 /* Nimble.framework in Frameworks */,
-				5F814FD71D1A72A6003670A4 /* OHHTTPStubs.framework in Frameworks */,
-				5F814FD51D1A72A6003670A4 /* Quick.framework in Frameworks */,
+				5C53A7FA2703F48100A7C0A3 /* Quick.xcframework in Frameworks */,
+				5C53A7FB2703F48100A7C0A3 /* Nimble.xcframework in Frameworks */,
+				5C53A7FC2703F48100A7C0A3 /* OHHTTPStubs.xcframework in Frameworks */,
 				5FEAE1D11D1A5154005C0028 /* Lock.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -850,14 +857,13 @@
 		5FEAE2111D1A5716005C0028 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5C49EB2D23EB138C008D562F /* JWTDecode.framework */,
-				5B416D951EE7475B009BA5BD /* SimpleKeychain.framework */,
-				5F390E881D63A5B800FC549C /* CleanroomLogger.framework */,
-				5F390E891D63A5B800FC549C /* CleanroomASL.framework */,
-				5F814FD21D1A7294003670A4 /* Auth0.framework */,
-				5F814FD01D1A7294003670A4 /* Quick.framework */,
-				5F814FD11D1A7294003670A4 /* Nimble.framework */,
-				5F814FD31D1A7294003670A4 /* OHHTTPStubs.framework */,
+				5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */,
+				5C53A8012703F4AB00A7C0A3 /* CleanroomLogger.xcframework */,
+				5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */,
+				5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */,
+				5C53A7F82703F48100A7C0A3 /* Nimble.xcframework */,
+				5C53A7F92703F48100A7C0A3 /* OHHTTPStubs.xcframework */,
+				5C53A7F72703F48100A7C0A3 /* Quick.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -933,7 +939,6 @@
 				5FEADCF01D1A7EBC0032D810 /* Sources */,
 				5FEADCF11D1A7EBC0032D810 /* Frameworks */,
 				5FEADCF21D1A7EBC0032D810 /* Resources */,
-				5FEADD061D1A7ECA0032D810 /* Carthage */,
 				5F99AA8D1D1B4BEF00D27842 /* CopyFiles */,
 				5FC4348D1D1E02EF005188BC /* Auth0 */,
 			);
@@ -1095,7 +1100,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"${CONFIGURATION}\" = \"Debug\" ]] && [ -z ${CIRCLECI} ] && which swiftlint >/dev/null; then\nswiftlint\nfi";
+			shellScript = "if [[ \"${CONFIGURATION}\" = \"Debug\" ]] && [ -z ${CIRCLECI} ] && which swiftlint >/dev/null; then\nswiftlint\nfi\n";
 		};
 		5FC4348D1D1E02EF005188BC /* Auth0 */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1110,24 +1115,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "AUTH0_PLIST=\"${SRCROOT}/Auth0.plist\"\nif [ -f \"$AUTH0_PLIST\" ];\nthen\ncp \"$AUTH0_PLIST\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\"\nfi\n";
-		};
-		5FEADD061D1A7ECA0032D810 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Auth0.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/CleanroomLogger.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/SimpleKeychain.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/JWTDecode.framework",
-			);
-			name = Carthage;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1377,7 +1364,11 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LockUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.LockUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1396,7 +1387,11 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LockUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.LockUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1413,13 +1408,12 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Lock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1436,13 +1430,12 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Lock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1559,7 +1552,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -1578,14 +1572,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = Lock/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.ios.Lock;
 				PRODUCT_NAME = Lock;
@@ -1604,14 +1598,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = Lock/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.ios.Lock;
 				PRODUCT_NAME = Lock;
 				SKIP_INSTALL = YES;
@@ -1623,12 +1617,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = LockTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.LockTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LockApp.app/LockApp";
@@ -1639,12 +1633,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = LockTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.LockTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LockApp.app/LockApp";

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Version](https://img.shields.io/cocoapods/v/Lock.svg?style=flat-square)](https://cocoadocs.org/docsets/Lock)
 [![License](https://img.shields.io/cocoapods/l/Lock.svg?style=flat-square)](https://cocoadocs.org/docsets/Lock)
 [![Platform](https://img.shields.io/cocoapods/p/Lock.svg?style=flat-square)](https://cocoadocs.org/docsets/Lock)
-![Swift 5.3](https://img.shields.io/badge/Swift-5.3-orange.svg?style=flat-square)
+![Swift 5.5](https://img.shields.io/badge/Swift-5.5-orange.svg?style=flat-square)
 
 [Auth0](https://auth0.com) is an authentication broker that supports social identity providers as well as enterprise identity providers such as Active Directory, LDAP, Google Apps and Salesforce.
 
@@ -36,7 +36,7 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md).
 ## Requirements
 
 - iOS 9+
-- Xcode 11.4+ / 12.x
+- Xcode 12.x / 13.x
 - Swift 4.x / 5.x
 
 ## Installation
@@ -61,7 +61,7 @@ If you are using [Carthage](https://github.com/Carthage/Carthage), add the follo
 github "auth0/Lock.swift" ~> 2.23
 ```
 
-Then run `carthage bootstrap`.
+Then run `carthage bootstrap --use-xcframeworks --platform iOS`.
 
 > For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,3 @@
-skip_docs
 opt_out_usage
 
 default_platform :ios
@@ -9,22 +8,13 @@ platform :ios do
     setup_circle_ci
   end
 
-  desc "Installs dependencies using Carthage"
-  lane :dependencies do |options|
-    action = options[:action]
-    carthage(use_binaries: false, command: action, cache_builds: true, platform: 'iOS')
-  end
-
-  desc "Bootstrap the development environment"
-  lane :bootstrap do
-    dependencies
-  end
-
   desc "Run code linter"
   lane :lint do
     swiftlint(
       mode: :lint,
-      config_file: '.swiftlint.yml'
+   		config_file: '.swiftlint.yml',
+      reporter: 'emoji',
+      raise_if_swiftlint_error: true
     )
   end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -8,38 +8,14 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-## Choose your installation method:
-
-<table width="100%" >
-<tr>
-<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
-<th width="33%">Installer Script</td>
-<th width="33%">Rubygems</td>
-</tr>
-<tr>
-<td width="33%" align="center">macOS</td>
-<td width="33%" align="center">macOS</td>
-<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
-</tr>
-<tr>
-<td width="33%"><code>brew cask install fastlane</code></td>
-<td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
-<td width="33%"><code>sudo gem install fastlane -NV</code></td>
-</tr>
-</table>
+Install _fastlane_ using
+```
+[sudo] gem install fastlane -NV
+```
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS
-### ios dependencies
-```
-fastlane ios dependencies
-```
-Installs dependencies using Carthage
-### ios bootstrap
-```
-fastlane ios bootstrap
-```
-Bootstrap the development environment
 ### ios lint
 ```
 fastlane ios lint
@@ -55,26 +31,29 @@ Runs all the tests
 fastlane ios ci
 ```
 Runs all the tests in a CI environment
+### ios pod_lint
+```
+fastlane ios pod_lint
+```
+Cocoapods library lint
 ### ios i18n
 ```
 fastlane ios i18n
 ```
 
-### ios screenshots
+### ios release_perform
 ```
-fastlane ios screenshots
+fastlane ios release_perform
 ```
-UI Screenshots
-### ios release
+Performs the prepared release by creating a tag and pushing to remote
+### ios release_publish
 ```
-fastlane ios release
+fastlane ios release_publish
 ```
-Releases the library to Cocoapods & Github Releases and updates README/CHANGELOG
-
-You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]
+Releases the library to CocoaPods trunk & Github Releases
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -1,4 +1,4 @@
 scheme "Lock"
-device "iPhone 11"
+device "iPhone 12"
 
 clean true

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -2,11 +2,7 @@
 
 # A list of devices you want to take the screenshots from
 devices([
-  #"iPhone SE",
-  "iPhone 8",
-  #"iPhone 8 Plus",
-  "iPhone X",
-  #"iPad Air 2",
+  "iPhone 12"
 ])
 
 languages([


### PR DESCRIPTION
### Changes

This PR migrates the library Xcode project to use XCFramework dependencies instead of fat frameworks, updating the CI and Fastlane config accordingly as well.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed