### PR TITLE
Add ability to input code when using magic links [SDK-2826]

### DIFF
--- a/Lock/Base.lproj/Lock.strings
+++ b/Lock/Base.lproj/Lock.strings
@@ -246,6 +246,8 @@
 "com.auth0.passwordless.email.title.social" = "Otherwise, enter your email to sign in or create an account.";
 // Passwordless link reminder action
 "com.auth0.passwordless.link.reminder" = "Did not receive the link?";
+// Passwordless input link code manually action
+"com.auth0.passwordless.link.code" = "I have a code";
 // Passwordless link sent to %@{identifier}
 "com.auth0.passwordless.link.sent" = "We sent you a link to sign in to %1$@";
 // Passwordless code sent by sms to %@{identifier}

--- a/Lock/PasswordlessPresenter.swift
+++ b/Lock/PasswordlessPresenter.swift
@@ -96,11 +96,7 @@ class PasswordlessPresenter: Presentable, Loggable {
             action(button)
         }
         view.secondaryButton?.onPress = { _ in
-            if self.options.passwordlessMethod == .magicLink {
-                self.navigator.navigate(Route.passwordless(screen: .code, connection: self.connection))
-            } else {
-                self.navigator.onBack()
-            }
+            self.navigator.onBack()
         }
 
         return view
@@ -178,7 +174,11 @@ class PasswordlessPresenter: Presentable, Loggable {
                           countryCode: self.interactor.countryCode,
                           method: self.options.passwordlessMethod)
         view.secondaryButton?.onPress = { _ in
-            self.navigator.onBack()
+            if self.options.passwordlessMethod == .magicLink {
+                self.navigator.navigate(Route.passwordless(screen: .code, connection: self.connection))
+            } else {
+                self.navigator.onBack()
+            }
         }
         return view
     }

--- a/Lock/PasswordlessPresenter.swift
+++ b/Lock/PasswordlessPresenter.swift
@@ -96,7 +96,11 @@ class PasswordlessPresenter: Presentable, Loggable {
             action(button)
         }
         view.secondaryButton?.onPress = { _ in
-            self.navigator.onBack()
+            if self.options.passwordlessMethod == .magicLink {
+                self.navigator.navigate(Route.passwordless(screen: .code, connection: self.connection))
+            } else {
+                self.navigator.onBack()
+            }
         }
 
         return view
@@ -170,7 +174,9 @@ class PasswordlessPresenter: Presentable, Loggable {
 
     private func showLinkSent() -> View {
         let view = PasswordlessView()
-        view.showLinkSent(identifier: self.interactor.identifier, countryCode: self.interactor.countryCode)
+        view.showLinkSent(identifier: self.interactor.identifier,
+                          countryCode: self.interactor.countryCode,
+                          method: self.options.passwordlessMethod)
         view.secondaryButton?.onPress = { _ in
             self.navigator.onBack()
         }

--- a/Lock/PasswordlessView.swift
+++ b/Lock/PasswordlessView.swift
@@ -158,7 +158,7 @@ class PasswordlessView: UIView, View {
         self.container?.addArrangedSubview(secondaryButton)
     }
 
-    func showLinkSent(identifier: String?, countryCode: CountryCode?) {
+    func showLinkSent(identifier: String?, countryCode: CountryCode?, method: PasswordlessMethod) {
         let secondaryButton = SecondaryButton()
         let imageView = UIImageView()
         let messageLabel = UILabel()
@@ -191,7 +191,11 @@ class PasswordlessView: UIView, View {
         messageLabel.textColor = Style.Auth0.textColor
         messageLabel.text = String(format: "We sent you a link to sign in to %1$@".i18n(key: "com.auth0.passwordless.link.sent", comment: "Passwordless link sent to %@{identifier}"),
                                    displayIdentifier)
-        secondaryButton.title = "Did not receive the link?".i18n(key: "com.auth0.passwordless.link.reminder", comment: "Passwordless link reminder action")
+        if method == .magicLink {
+            secondaryButton.title = "I have a code".i18n(key: "com.auth0.passwordless.link.code", comment: "Passwordless input link code manually action")
+        } else {
+            secondaryButton.title = "Did not receive the link?".i18n(key: "com.auth0.passwordless.link.reminder", comment: "Passwordless link reminder action")
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/LockTests/Presenters/PasswordlessPresenterSpec.swift
+++ b/LockTests/Presenters/PasswordlessPresenterSpec.swift
@@ -282,6 +282,14 @@ class PasswordlessPresenterSpec: QuickSpec {
                 it("should expect title on secondary button") {
                     expect(view.secondaryButton!.title).to(contain("Did not receive the link"))
                 }
+
+                it("should expect title on secondary button if using magic links") {
+                    options.passwordlessMethod = .magicLink
+                    presenter = PasswordlessPresenter(interactor: interactor, connection: connection, navigator: navigator, options: options, screen: screen)
+                    view = presenter.view as? PasswordlessView
+
+                    expect(view.secondaryButton!.title).to(contain("I have a code"))
+                }
                 
             }
         }
@@ -537,9 +545,15 @@ class PasswordlessPresenterSpec: QuickSpec {
                     expect(view.secondaryButton!.title).to(contain("Did not receive the link"))
                 }
                 
+                it("should expect title on secondary button if using magic links") {
+                    options.passwordlessMethod = .magicLink
+                    presenter = PasswordlessPresenter(interactor: interactor, connection: connection, navigator: navigator, options: options, screen: screen)
+                    view = presenter.view as? PasswordlessView
+
+                    expect(view.secondaryButton!.title).to(contain("I have a code"))
+                }
+
             }
         }
     }
 }
-
-


### PR DESCRIPTION
### Changes

This PR adds the possibility to input the passwordless code manually when using magic links. Such functionality was already available on Lock.Android:

https://user-images.githubusercontent.com/5055789/135938940-9deca1ff-6e68-4eae-8849-46a4f9022817.mov

### References

Closes https://github.com/auth0/Lock.swift/issues/670

### Testing

This change was tested manually on both an iPhone 13 simulator (iOS 15) and a physical iPhone 11 Pro (iOS 15), using Xcode 13.

https://user-images.githubusercontent.com/5055789/135938833-1a07af19-601c-402e-b07b-567f6e83ad43.MP4

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed