### PR TITLE
Add note to the README about Auth0.swift version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md).
 - Xcode 12.x / 13.x
 - Swift 4.x / 5.x
 
+**Lock.swift uses Auth0.swift 1.x**.
+
 ## Installation
 
 #### Cocoapods


### PR DESCRIPTION
### Changes

This PR adds a brief note to the README to document the fact that Lock.swift uses Auth0.swift 1.x.

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed