### PR TITLE
Use Codecov orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@3
+
 executors:
   macos-executor:
     parameters:
@@ -62,8 +65,10 @@ commands:
           name: Run iOS tests
           command: bundle exec fastlane ios ci
       - run:
-          name: Upload coverage report
-          command: bash <(curl -s https://codecov.io/bash) -J '<< parameters.scheme >>'
+          name: Generate coverage report
+          command: bundle exec slather coverage -x --output-directory output --arch x86_64 --scheme << parameters.scheme >> << parameters.scheme >>.xcodeproj
+      - codecov/upload:
+          file: output/cobertura.xml
       - run:
           name: Run pod lib lint
           command: bundle exec fastlane ios pod_lint
@@ -93,7 +98,7 @@ workflows:
   build:
     jobs:
       - build-and-test:
-          scheme: "Lock"
+          scheme: Lock
           matrix:
             parameters:
               xcode: ["13.0.0", "12.5.1"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'fastlane'
-gem "cocoapods"
+gem 'cocoapods'
+gem 'slather'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval(File.read(plugins_path), binding) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.1.0)
+    clamp (1.3.2)
     cocoapods (1.11.3)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
@@ -155,6 +156,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-auth0_shipper (0.4.1)
+      semantic (~> 1.5)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -209,6 +212,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -217,10 +221,14 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     optparse (0.1.1)
     os (1.1.4)
     plist (3.6.0)
     public_suffix (4.0.7)
+    racc (1.6.0)
     rake (13.0.6)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -233,6 +241,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     security (0.1.3)
+    semantic (1.6.1)
     signet (0.16.1)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.0)
@@ -241,6 +250,12 @@ GEM
     simctl (1.6.8)
       CFPropertyList
       naturally
+    slather (2.7.2)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport
+      clamp (~> 1.3)
+      nokogiri (~> 1.12)
+      xcodeproj (~> 1.21)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -279,6 +294,8 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
+  fastlane-plugin-auth0_shipper
+  slather
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
### Changes

This PR updates the CI config to use the Codecov orb instead of the bash uploader.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed