### PR TITLE
Add redesigned README [SDK-3703]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+> ⚠️ Tests must be added for all new functionality. Existing tests must be updated for all changed/fixed functionality, where applicable. All tests must complete without errors. All new functionality must be documented as well.
+
+## Environment setup
+
+We use [Carthage](https://github.com/Carthage/Carthage) to manage Lock.swift's dependencies. 
+
+1. Clone this repository and enter its root directory.
+2. Run `carthage bootstrap --use-xcframeworks` to fetch and build the dependencies.
+3. Open `Lock.xcodeproj` in Xcode.
+4. To build the `Lock` framework target for the first time, build the test app first. This is necessary due to the way the dependencies are set up.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -51,13 +51,13 @@ Lock
 
 If you are using a Database connection in Lock then you will need to enable the Password Grant Type, please follow the [Update Grant Types](https://auth0.com/docs/get-started/applications/update-grant-types) guide.
 
-#### Specify connections
+### Specify connections
 
 Lock will automatically load your application configuration automatically, if you wish to override this behaviour you can manually specify which of your connections to use.  
 
 Before presenting Lock you can tell it what connections it should display and use to authenticate an user. You can do that by calling the method and supply a closure that can specify the connections.
 
-##### Adding a Database connection
+#### Adding a Database connection
 
 ```swift
 .withConnections {
@@ -65,7 +65,7 @@ Before presenting Lock you can tell it what connections it should display and us
 }
 ```
 
-##### Adding Social connections
+#### Adding Social connections
 
 ```swift
 .withConnections { connections in
@@ -74,7 +74,7 @@ Before presenting Lock you can tell it what connections it should display and us
 }
 ```
 
-##### Adding Enterprise connections
+#### Adding Enterprise connections
 
 ```swift
 .withConnections { connections in
@@ -147,7 +147,7 @@ Lock
 
 > ⚠️ Passwordless can only be used with a single connection and will prioritize the use of email connections over sms.
 
-#### Passwordless method
+### Passwordless method
 
 When using Lock Passwordless the default `passwordlessMethod` is `.code` which sends the user a one time passcode to login. If you want to use [Universal Links](https://auth0.com/docs/get-started/applications/enable-universal-links-support-in-apple-xcode) you can add the following:
 
@@ -157,7 +157,7 @@ When using Lock Passwordless the default `passwordlessMethod` is `.code` which s
 }
 ```
 
-#### Activity callback
+### Activity callback
 
 If you are using Lock Passwordless and have specified the `.magicLink` option to send the user a universal link then you will need to add the following to your `AppDelegate.swift`:
 
@@ -167,9 +167,9 @@ func application(_ application: UIApplication, continue userActivity: NSUserActi
 }
 ```
 
-#### Adding a Passwordless connection
+### Adding a Passwordless connection
 
-##### SMS
+#### SMS
 
 ```swift
 .withConnections {
@@ -177,7 +177,7 @@ func application(_ application: UIApplication, continue userActivity: NSUserActi
 }
 ```
 
-##### Email
+#### Email
 
 ```swift
 .withConnections {
@@ -231,7 +231,7 @@ iPad presentation is show in a modal popup, this can be disabled to use full scr
 
 Lock.swift provides numerous options to customize the Lock experience.
 
-#### Closable
+### Closable
 
 Allows Lock to be dismissed by the user. Defaults to `false`.
 
@@ -241,7 +241,7 @@ Allows Lock to be dismissed by the user. Defaults to `false`.
 }
 ```
 
-#### Terms of Service
+### Terms of Service
 
 By default Lock will use Auth0's [Terms of Service](https://auth0.com/web-terms) and [Privacy Policy](https://auth0.com/privacy):
 
@@ -274,7 +274,7 @@ Database connection will display the Terms of Service dialog. Defaults to `true`
 
 > ⚠️ Terms will always be shown if the `mustAcceptTerms` flag has been enabled.
 
-#### Logging
+### Logging
 
 * **logLevel**: Defaults to `.off`. *Syslog* logging levels are supported.
 * **logHttpRequest**: Log Auth0.swift API requests. Defaults to `false`.
@@ -314,7 +314,7 @@ class CleanroomLockLogger: LoggerOutput {
 }
 ```
 
-#### Scope
+### Scope
 
 Scope used for authentication. By default is `openid`. It will return not only the **access_token**, but also an **id_token** which is a [JSON Web Token (JWT)](https://jwt.io/) containing user information.
 
@@ -324,7 +324,7 @@ Scope used for authentication. By default is `openid`. It will return not only t
 }
 ```
 
-#### Connection scope
+### Connection scope
 
 Allows you to set provider scopes for OAuth2/Social connections with a comma separated list. By default is empty.
 
@@ -333,7 +333,7 @@ Allows you to set provider scopes for OAuth2/Social connections with a comma sep
   $0.connectionScope = ["github": "public_repo read:user"]
 ```
 
-#### Database
+### Database
 
 - **allow**: Which database screens will be accessible, the default is enable all screens e.g. `.Login, .Signup, .ResetPassword`
 - **initialScreen**: The first screen to present to the user, the default is `.login`.
@@ -347,7 +347,7 @@ Allows you to set provider scopes for OAuth2/Social connections with a comma sep
 }
 ```
 
-#### Custom signup fields
+### Custom signup fields
 
 When signing up the default information requirements are the user's *email* and *password*. You can expand your data capture requirements as needed.
 
@@ -367,7 +367,7 @@ When signing up, your app may need to assign values to the user's profile that a
 
 > ⚠️ You must specify the icon to use with your custom text field and store it in your App's bundle.
 
-#### Password manager
+### Password manager
 
 This functionality has been removed as of Release 2.18 due to the 1Password extension using deprecated methods, which can result in your app being rejected by the AppStore. This functionality was superseded in iOS 12 when Apple introduced the integration of password managers into login forms.
 
@@ -390,7 +390,7 @@ You may also safely remove the following entry from your app's `Info.plist`:
 </array>
 ```
 
-#### Show password
+### Show password
 
 By default a show password icon is shown in password fields to toggle visibility of the input text. You can disable this using the `allowShowPassword` option:
 
@@ -402,7 +402,7 @@ By default a show password icon is shown in password fields to toggle visibility
 
 > ⚠️ Show password will not be available if the **Password Manager** is available.
 
-#### Enterprise
+### Enterprise
 
 * **enterpriseConnectionUsingActiveAuth**: By default Enterprise connections will use Web Authentication. However you can specify which connections will alternatively use credential authentication and prompt for a username and password.
 * **activeDirectoryEmailAsUsername**: When Lock request your enterprise credentials after performing Home Realm Discovery (HRD), e.g. for Active Directory, it will try to prefill the username for you. By default it will parse the email's local part and use that as the username, e.g. `john.doe@auth0.com` will be `john.doe`. If you don't want that you can turn on this flag and it will just use the email address.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,419 @@
+# Examples
+
+- [Lock Classic](#lock-classic)
+- [Lock Passwordless](#lock-passwordless)
+- [Styling Lock](#styling-lock)
+- [Customization Options](#customization-options)
+
+---
+
+## Lock Classic
+
+Lock Classic handles authentication using Database, Social, and Enterprise connections.
+
+### OIDC conformant mode
+
+It is strongly encouraged that this SDK be used in OIDC Conformant mode. When this mode is enabled, it will force the SDK to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. Defaults to `false`.
+
+```swift
+.withOptions {
+    $0.oidcConformant = true
+}
+```
+
+For more information, please see the [OIDC adoption guide](https://auth0.com/docs/authenticate/login/oidc-conformant-authentication).
+
+To show Lock, add the following snippet in your `UIViewController`:
+
+```swift
+Lock
+    .classic()
+    .withOptions {
+        $0.closable = false
+        $0.oidcConformant = true
+    }
+    .withStyle {
+      $0.title = "Welcome to my App!"
+    }
+    .onAuth {
+      print("Obtained credentials \($0)")
+    }
+    .onError {
+      print("Failed with \($0)")
+    }
+    .onCancel {
+      print("User cancelled")
+    }
+    .present(from: self)
+```
+
+### Important: Database connection authentication
+
+If you are using a Database connection in Lock then you will need to enable the Password Grant Type, please follow the [Update Grant Types](https://auth0.com/docs/get-started/applications/update-grant-types) guide.
+
+#### Specify connections
+
+Lock will automatically load your application configuration automatically, if you wish to override this behaviour you can manually specify which of your connections to use.  
+
+Before presenting Lock you can tell it what connections it should display and use to authenticate an user. You can do that by calling the method and supply a closure that can specify the connections.
+
+##### Adding a Database connection
+
+```swift
+.withConnections {
+    $0.database(name: "Username-Password-Authentication", requiresUsername: true)
+}
+```
+
+##### Adding Social connections
+
+```swift
+.withConnections { connections in
+    connections.social(name: "google-oauth2", style: .Google)
+    connections.social(name: "github", style: .Github)
+}
+```
+
+##### Adding Enterprise connections
+
+```swift
+.withConnections { connections in
+    connections.enterprise(name: "customAD", domains: ["domain1.com", "domain2.com"])
+    connections.enterprise(name: "alternativeAD", domains: ["domain3.com"], style: .Microsoft)
+}
+```
+
+### Custom domains
+
+If you are using [Custom Domains](https://auth0.com/docs/customize/custom-domains), you will need to set the `configurationBaseURL` to your Auth0 Domain so the Lock configuration can 
+be read correctly:
+
+```swift
+.withOptions {
+   $0.configurationBase = "https://YOUR_DOMAIN.auth0.com"
+}
+```
+
+### Logging
+
+You can easily turn on/off logging capabilities:
+
+```swift
+Lock
+    .classic()
+    .withOptions {
+        $0.logLevel = .all
+        $0.logHttpRequest = true
+    }
+```
+
+[Go up ⤴](#examples)
+
+## Lock Passwordless
+
+Lock Passwordless handles authentication using Passwordless and Social connections.
+
+> 💡 The Passwordless feature requires your application to have the *Passwordless OTP* Grant Type enabled. Check [this article](https://auth0.com/docs/get-started/applications/application-grant-types) for more information.
+
+To use Passwordless Authentication with Lock, you need to configure it with **OIDC Conformant Mode** set to `true`.
+
+> 💡 OIDC Conformant Mode will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. By default this mode is disabled. For more information, please see the [OIDC adoption guide](https://auth0.com/docs/authenticate/login/oidc-conformant-authentication).
+
+To show Lock, add the following snippet in your `UIViewController`:
+
+```swift
+Lock
+    .passwordless()
+    .withOptions {
+        $0.oidcConformant = true
+    }
+    .withStyle {
+      $0.title = "Welcome to my App!"
+    }
+    .onAuth {
+      print("Obtained credentials \($0)")
+    }
+    .onError {
+      print("Failed with \($0)")
+    }
+    .onCancel {
+      print("User cancelled")
+    }
+    .onPasswordless {
+      print("Passwordless requested for \($0)")
+    }
+    .present(from: self)
+```
+
+> ⚠️ Passwordless can only be used with a single connection and will prioritize the use of email connections over sms.
+
+#### Passwordless method
+
+When using Lock Passwordless the default `passwordlessMethod` is `.code` which sends the user a one time passcode to login. If you want to use [Universal Links](https://auth0.com/docs/get-started/applications/enable-universal-links-support-in-apple-xcode) you can add the following:
+
+```swift
+.withOptions {
+    $0.passwordlessMethod = .magicLink
+}
+```
+
+#### Activity callback
+
+If you are using Lock Passwordless and have specified the `.magicLink` option to send the user a universal link then you will need to add the following to your `AppDelegate.swift`:
+
+```swift
+func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+    return Lock.continueAuth(using: userActivity)
+}
+```
+
+#### Adding a Passwordless connection
+
+##### SMS
+
+```swift
+.withConnections {
+    $0.sms(name: "sms")
+}
+```
+
+##### Email
+
+```swift
+.withConnections {
+    $0.email(name: "email")
+}
+```
+
+[Go up ⤴](#examples)
+
+## Styling Lock
+
+Lock.swift provides many styling options to help you apply your own brand identity to Lock.
+
+### iPad modal presentation
+
+iPad presentation is show in a modal popup, this can be disabled to use full screen as follows:
+
+```swift
+.withStyle {
+  $0.modalPopup = false
+}
+```
+
+### Customize your header and primary color
+
+```swift
+.withStyle {
+  $0.title = "Company LLC"
+  $0.logo = UIImage(named: "company_logo")
+  $0.primaryColor = UIColor(red: 0.6784, green: 0.5412, blue: 0.7333, alpha: 1.0)
+}
+```
+
+> 💡 You can explore the full range of styling options in [Style.swift](https://github.com/auth0/Lock.swift/blob/master/Lock/Style.swift).
+
+### Styling a custom OAuth2 connection
+
+```swift
+.withStyle {
+  $0.oauth2["slack"] = AuthStyle(
+      name: "Slack",
+      color: UIColor(red: 0.4118, green: 0.8078, blue: 0.6588, alpha: 1.0),
+      withImage: UIImage(named: "ic_slack")
+  )
+}
+```
+
+[Go up ⤴](#examples)
+
+## Customization options
+
+Lock.swift provides numerous options to customize the Lock experience.
+
+#### Closable
+
+Allows Lock to be dismissed by the user. Defaults to `false`.
+
+```swift
+.withOptions {
+    $0.closable = true
+}
+```
+
+#### Terms of Service
+
+By default Lock will use Auth0's [Terms of Service](https://auth0.com/web-terms) and [Privacy Policy](https://auth0.com/privacy):
+
+```swift
+.withOptions {
+    $0.termsOfService = "https://example.com/terms"
+    $0.privacyPolicy = "https://example.com/privacy"
+}
+```
+
+#### Must accept Terms of Service
+
+Database connection will require explicit acceptance of Terms of Service:
+
+```swift
+.withOptions {
+    $0.mustAcceptTerms = true
+}
+```
+
+#### Show Terms of Service
+
+Database connection will display the Terms of Service dialog. Defaults to `true`.
+
+```swift
+.withOptions {
+    $0.showTerms = true
+}
+```
+
+> ⚠️ Terms will always be shown if the `mustAcceptTerms` flag has been enabled.
+
+#### Logging
+
+* **logLevel**: Defaults to `.off`. *Syslog* logging levels are supported.
+* **logHttpRequest**: Log Auth0.swift API requests. Defaults to `false`.
+* **loggerOutput**: Specify output handler, by default this uses the `print` statement.
+
+```swift
+.withOptions {
+    $0.logLevel = .all
+    $0.logHttpRequest = true
+    $0.loggerOutput = CleanroomLockLogger()
+}
+```
+
+In the code above, the *loggerOutput* has been set to use [CleanroomLogger](https://github.com/emaloney/CleanroomLogger).
+This can typically be achieved by implementing the *loggerOutput* protocol.  You can of course use your favorite logger library.
+
+```swift
+class CleanroomLockLogger: LoggerOutput {
+  func message(_ message: String, level: LoggerLevel, filename: String, line: Int) {
+    let channel: LogChannel?
+    switch level {
+    case .debug:
+        channel = Log.debug
+    case .error:
+        channel = Log.error
+    case .info:
+        channel = Log.info
+    case .verbose:
+        channel = Log.verbose
+    case .warn:
+        channel = Log.warning
+    default:
+        channel = nil
+    }
+    channel?.message(message, filePath: filename, fileLine: line)
+  }
+}
+```
+
+#### Scope
+
+Scope used for authentication. By default is `openid`. It will return not only the **access_token**, but also an **id_token** which is a [JSON Web Token (JWT)](https://jwt.io/) containing user information.
+
+```swift
+.withOptions {
+  $0.scope = "openid profile email offline_access"
+}
+```
+
+#### Connection scope
+
+Allows you to set provider scopes for OAuth2/Social connections with a comma separated list. By default is empty.
+
+```swift
+.withOptions {
+  $0.connectionScope = ["github": "public_repo read:user"]
+```
+
+#### Database
+
+- **allow**: Which database screens will be accessible, the default is enable all screens e.g. `.Login, .Signup, .ResetPassword`
+- **initialScreen**: The first screen to present to the user, the default is `.login`.
+- **usernameStyle**: Specify the type of identifier the login will require.  The default is either `[.Username, .Email]`.  However it's important to note that this option is only active if you have set the **requires_username** flag to `true` in your [Auth0 Dashboard](https://manage.auth0.com/#/)
+
+```swift
+.withOptions {
+  $0.allow = [.Login, .ResetPassword]
+  $0.initialScreen = .login
+  $0.usernameStyle = [.Username]
+}
+```
+
+#### Custom signup fields
+
+When signing up the default information requirements are the user's *email* and *password*. You can expand your data capture requirements as needed.
+
+If you want to save the value of the attribute in the root of a user's profile, ensure you set the  `storage` parameter to `.rootAttribute`. Only a subset of values can be stored this way. The list of attributes that can be added to your root profile is [here](https://auth0.com/docs/api/authentication#signup). By default, every additional sign up field is stored inside the user's `user_metadata` object.
+
+When signing up, your app may need to assign values to the user's profile that are not entered by the user. The `hidden` property of `CustomTextField` prevents the signup field from being shown to the user, allowing your app to assign default values to the user profile.
+
+```swift
+.withOptions {
+  $0.customSignupFields = [
+    CustomTextField(name: "first_name", placeholder: "First Name", storage: .rootAttribute, icon: UIImage(named: "ic_person", bundle: Lock.bundle), contentType: .givenName),
+    CustomTextField(name: "last_name", placeholder: "Last Name", storage: .rootAttribute, icon: UIImage(named: "ic_person", bundle: Lock.bundle), contentType: .familyName),
+    CustomTextField(name: "referral_code", placeholder: "Referral Code", defaultValue: referralCode, hidden: true)
+  ]
+}
+```
+
+> ⚠️ You must specify the icon to use with your custom text field and store it in your App's bundle.
+
+#### Password manager
+
+This functionality has been removed as of Release 2.18 due to the 1Password extension using deprecated methods, which can result in your app being rejected by the AppStore. This functionality was superseded in iOS 12 when Apple introduced the integration of password managers into login forms.
+
+The following options are now deprecated:
+
+```swift
+.withOptions {
+    $0.passwordManager.enabled = false
+    $0.passwordManager.appIdentifier = "www.example.com"
+    $0.passwordManager.displayName = "My App"
+}
+```
+
+You may also safely remove the following entry from your app's `Info.plist`:
+
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>org-appextension-feature-password-management</string>
+</array>
+```
+
+#### Show password
+
+By default a show password icon is shown in password fields to toggle visibility of the input text. You can disable this using the `allowShowPassword` option:
+
+```swift
+.withOptions {
+    $0.allowShowPassword = false
+}
+```
+
+> ⚠️ Show password will not be available if the **Password Manager** is available.
+
+#### Enterprise
+
+* **enterpriseConnectionUsingActiveAuth**: By default Enterprise connections will use Web Authentication. However you can specify which connections will alternatively use credential authentication and prompt for a username and password.
+* **activeDirectoryEmailAsUsername**: When Lock request your enterprise credentials after performing Home Realm Discovery (HRD), e.g. for Active Directory, it will try to prefill the username for you. By default it will parse the email's local part and use that as the username, e.g. `john.doe@auth0.com` will be `john.doe`. If you don't want that you can turn on this flag and it will just use the email address.
+
+```swift
+.withOptions {
+  $0.activeDirectoryEmailAsUsername = true
+  $0.enterpriseConnectionUsingActiveAuth = ["example.com"]
+}
+```
+
+---
+
+[Go up ⤴](#examples)

--- a/README.md
+++ b/README.md
@@ -1,555 +1,184 @@
-# Lock.swift 
+![Lock.swift](https://cdn.auth0.com/website/sdks/banners/lock-swift-banner.png)
 
-[![CircleCI](https://img.shields.io/circleci/project/github/auth0/Lock.swift.svg?style=flat-square)](https://circleci.com/gh/auth0/Lock.swift/tree/master)
-[![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Lock.swift/master.svg?style=flat-square)](https://codecov.io/github/auth0/Lock.swift)
-[![Version](https://img.shields.io/cocoapods/v/Lock.svg?style=flat-square)](https://cocoadocs.org/docsets/Lock)
-[![License](https://img.shields.io/cocoapods/l/Lock.svg?style=flat-square)](https://cocoadocs.org/docsets/Lock)
-[![Platform](https://img.shields.io/cocoapods/p/Lock.svg?style=flat-square)](https://cocoadocs.org/docsets/Lock)
-![Swift 5.5](https://img.shields.io/badge/Swift-5.5-orange.svg?style=flat-square)
+![Version](https://img.shields.io/cocoapods/v/Lock.svg?style=flat)
+[![CircleCI](https://img.shields.io/circleci/project/github/auth0/Lock.swift.svg?style=flat)](https://circleci.com/gh/auth0/Lock.swift/tree/master)
+[![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Lock.swift/master.svg?style=flat)](https://codecov.io/github/auth0/Lock.swift)
+![License](https://img.shields.io/github/license/auth0/Lock.swift.svg?style=flat)
 
-[Auth0](https://auth0.com) is an authentication broker that supports social identity providers as well as enterprise identity providers such as Active Directory, LDAP, Google Apps and Salesforce.
+📚 [**Documentation**](#documentation) • 🚀 [**Getting Started**](#getting-started) • 💬 [**Feedback**](#feedback)
 
-Lock makes it easy to integrate SSO in your app. You won't have to worry about:
+Migrating from v1? Check the [Migration Guide](MIGRATION.md).
 
-* Having a professional looking login dialog that displays well on any device.
-* Finding the right icons for popular social providers.
-* Solving the home realm discovery challenge with enterprise users (i.e.: asking the enterprise user the email, and redirecting to the right enterprise identity provider).
-* Implementing a standard sign in protocol (OpenID Connect / OAuth2 Login)
+## Documentation
 
-Need help migrating from v1? Please check our [Migration Guide](MIGRATION.md).
+- [**Examples**](EXAMPLES.md) - explains how to use Lock.swift.
+- [**Auth0 Documentation**](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 
-## Table of Contents
+## Getting Started
 
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Lock Classic](#lock-classic)
-- [Styling Lock](#styling-lock)
-- [Lock Passwordless](#lock-passwordless)
-- [Customization Options](#customization-options)
-- [What is Auth0?](#what-is-auth0)
-- [Create a Free Auth0 Account](#create-a-free-auth0-account)
-- [Issue Reporting](#issue-reporting)
-- [Author](#author)
-- [License](#license)
-
-## Requirements
+### Requirements
 
 - iOS 9+
-- Xcode 12.x / 13.x
+- Xcode 13.x / 14.x
 - Swift 4.x / 5.x
 
 **Lock.swift uses Auth0.swift 1.x**.
 
-## Installation
+### Installation
 
 #### Cocoapods
 
-If you are using [Cocoapods](https://cocoapods.org), add this line to your `Podfile`:
+Add the following line to your `Podfile`:
 
 ```ruby
 pod "Lock", "~> 2.24"
 ```
 
-Then run `pod install`.
-
-> For more information on Cocoapods, check [their official documentation](https://guides.cocoapods.org/using/getting-started.html).
+Then, run `pod install`.
 
 #### Carthage
 
-If you are using [Carthage](https://github.com/Carthage/Carthage), add the following line to your `Cartfile`:
+Add the following line to your `Cartfile`:
 
 ```ruby
 github "auth0/Lock.swift" ~> 2.24
 ```
 
-Then run `carthage bootstrap --use-xcframeworks --platform iOS`.
+Then, run `carthage bootstrap --use-xcframeworks --platform iOS`.
 
-> For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
+#### Swift Package Manager
 
-#### SPM
-
-If you are using the Swift Package Manager, open the following menu item in Xcode:
+Open the following menu item in Xcode:
 
 **File > Add Packages...**
 
-In the **Search or Enter Package URL** search box enter this url: 
+In the **Search or Enter Package URL** search box enter this URL: 
 
-```
-https://github.com/auth0/Lock.swift.git
-```
-
-Then select the dependency rule and press **Add Package**.
-
-> For further reference on SPM, check [its official documentation](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app).
-
-## Usage
-
-First import **Lock**:
-
-```swift
-import Lock
+```text
+https://github.com/auth0/Lock.swift
 ```
 
-Next in your `AppDelegate.swift` add the following:
+Then, select the dependency rule and press **Add Package**.
 
-```swift
-func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-  return Lock.resumeAuth(url, options: options)
-}
-```
+### Configure the SDK
 
-### Configuration
+Head to the [Auth0 Dashboard](https://manage.auth0.com/#/applications/) and create a new **Native** application.
 
-In order to use Lock you need to provide your Auth0 Client ID and Domain.
+Lock.swift needs the **Client ID** and **Domain** of the Auth0 application to communicate with Auth0. You can find these details in the settings page of your Auth0 application. If you are using a [custom domain](https://auth0.com/docs/brand-and-customize/custom-domains), use the value of your custom domain instead of the value from the settings page.
 
-> The Auth0 Client ID & Domain can be found in your [Auth0 Dashboard](https://manage.auth0.com)
+#### Configure Client ID and Domain with a plist
 
-#### Auth0.plist file
-
-In your application bundle you can add a `plist` file named `Auth0.plist` with the following information:
+Create a `plist` file named `Auth0.plist` in your app bundle with the following content:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>ClientId</key>
-  <string>{YOUR_CLIENT_ID}</string>
-  <key>Domain</key>
-  <string>{YOUR_DOMAIN}</string>
+    <key>ClientId</key>
+    <string>YOUR_AUTH0_CLIENT_ID</string>
+    <key>Domain</key>
+    <string>YOUR_AUTH0_DOMAIN</string>
 </dict>
 </plist>
 ```
 
-## Lock Classic
+#### Configure Client ID and Domain programmatically
 
-Lock Classic handles authentication using Database, Social & Enterprise connections.
-
-### OIDC Conformant Mode
-
-It is strongly encouraged that this SDK be used in OIDC Conformant mode. When this mode is enabled, it will force the SDK to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. By default this is `false`.
-
-```swift
-.withOptions {
-    $0.oidcConformant = true
-}
-```
-
-For more information, please see the [OIDC adoption guide](https://auth0.com/docs/api-auth/tutorials/adoption).
-
-To show Lock, add the following snippet in your `UIViewController`:
+<details>
+  <summary>For Classic Lock</summary>
 
 ```swift
 Lock
-    .classic()
-    .withOptions {
-        $0.closable = false
-        $0.oidcConformant = true
-    }
-    .withStyle {
-      $0.title = "Welcome to my App!"
-    }
-    .onAuth {
-      print("Obtained credentials \($0)")
-    }
-    .onError {
-      print("Failed with \($0)")
-    }
-    .onCancel {
-      print("User cancelled")
-    }
-    .present(from: self)
+    .classic(clientId: "YOUR_AUTH0_CLIENT_ID", domain: "YOUR_AUTH0_DOMAIN")
+    // ...
 ```
+</details>
 
-### Important: Database Connection Authentication
-
-Since June 2017 new Clients no longer have the **Password Grant Type** enabled by default.
-If you are using a Database Connection in Lock then you will need to enable the Password Grant Type, please follow [this guide](https://auth0.com/docs/applications/concepts/application-grant-types#how-to-edit-the-client-grant_types-property).
-
-#### Specify connections
-
-Lock will automatically load your application configuration automatically, if you wish to override this behaviour you can manually specify which of your connections to use.  
-
-Before presenting Lock you can tell it what connections it should display and use to authenticate an user. You can do that by calling the method and supply a closure that can specify the connections.
-
-##### Adding a Database connection
-
-```swift
-.withConnections {
-    $0.database(name: "Username-Password-Authentication", requiresUsername: true)
-}
-```
-
-##### Adding Social connections
-
-```swift
-.withConnections { connections in
-    connections.social(name: "facebook", style: .Facebook)
-    connections.social(name: "google-oauth2", style: .Google)
-}
-```
-
-##### Adding Enterprise connections
-
-```swift
-.withConnections { connections in
-    connections.enterprise(name: "customAD", domains: ["domain1.com", "domain2.com"])
-    connections.enterprise(name: "alternativeAD", domains: ["domain3.com"], style: .Microsoft)
-}
-```
-
-### Custom Domains
-
-If you are using [Custom Domains](https://auth0.com/docs/custom-domains), you will need to set the `configurationBaseURL` to your Auth0 Domain so the Lock configuration can 
-be read correctly:
-
-```swift
-.withOptions {
-   $0.configurationBase = "https://<YOUR DOMAIN>.auth0.com"
-}
-```
-
-### Logging
-
-You can easily turn on/off logging capabilities:
+<details>
+  <summary>For Passwordless Lock</summary>
 
 ```swift
 Lock
-    .classic()
-    .withOptions {
-        $0.logLevel = .all
-        $0.logHttpRequest = true
-    }
+    .passwordless(clientId: "YOUR_AUTH0_CLIENT_ID", domain: "YOUR_AUTH0_DOMAIN")
+    // ...
 ```
+</details>
 
-## Styling Lock
+### Configure your app
 
-Lock provides many styling options to help you apply your own brand identity to Lock.
+Make sure Lock.swift can receive callback URLs.
 
-### iPad Modal Presentation
-
-iPad presentation is show in a modal popup, this can be disabled to use full screen as follows:
+<details>
+  <summary>Using the UIKit app lifecycle</summary>
 
 ```swift
-.withStyle {
-  $0.modalPopup = false
+// AppDelegate.swift
+
+import Lock
+
+// ...
+
+func application(_ app: UIApplication,
+                 open url: URL,
+                 options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
+    return Lock.resumeAuth(url, options: options)
 }
 ```
+</details>
 
-### Customize Your Header and Primary Color
+<details>
+  <summary>Using the UIKit app lifecycle with Scenes</summary>
 
 ```swift
-.withStyle {
-  $0.title = "Company LLC"
-  $0.logo = UIImage(named: "company_logo")
-  $0.primaryColor = UIColor(red: 0.6784, green: 0.5412, blue: 0.7333, alpha: 1.0)
+// SceneDelegate.swift
+
+import Lock
+
+// ...
+
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let url = URLContexts.first?.url else { return }
+    Lock.resumeAuth(url, options: [:])
 }
 ```
+</details>
 
-> You can explore the full range of styling options in [Style.swift](https://github.com/auth0/Lock.swift/blob/master/Lock/Style.swift)
+### Next steps
 
-### Styling a Custom OAuth2 Connection
+**Learn how to use Lock.swift in [Examples ↗](EXAMPLES.md)**
 
-```swift
-.withStyle {
-  $0.oauth2["slack"] = AuthStyle(
-      name: "Slack",
-      color: UIColor(red: 0.4118, green: 0.8078, blue: 0.6588, alpha: 1.0),
-      withImage: UIImage(named: "ic_slack")
-  )
-}
-```
+- [**Lock Classic**](EXAMPLES.md#lock-classic) - handles authentication using Database, Social, and Enterprise connections.
+- [**Lock Passwordless**](EXAMPLES.md#lock-passwordless) - handles authentication using Passwordless and Social connections.
 
-## Lock Passwordless
+## Feedback
 
-Lock Passwordless handles authentication using Passwordless & Social Connections.
+### Contributing
 
-> The Passwordless feature requires your application to have the *Passwordless OTP* Grant Type enabled. Check [this article](https://auth0.com/docs/applications/concepts/application-grant-types) for more information.
+We appreciate feedback and contribution to this repo! Before you get started, please see the following:
 
-To use Passwordless Authentication with Lock, you need to configure it with **OIDC Conformant Mode** set to `true`.
+- [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
+- [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
+- [Lock.swift's contribution guide](CONTRIBUTING.md)
 
-> OIDC Conformant Mode will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. By default this mode is disabled. For more information, please see the [OIDC adoption guide](https://auth0.com/docs/api-auth/tutorials/adoption).
+### Raise an issue
 
-To show Lock, add the following snippet in your `UIViewController`:
+To provide feedback or report a bug, please [raise an issue on our issue tracker](https://github.com/auth0/Lock.swift/issues).
 
-```swift
-Lock
-    .passwordless()
-    .withOptions {
-        $0.oidcConformant = true
-    }
-    .withStyle {
-      $0.title = "Welcome to my App!"
-    }
-    .onAuth {
-      print("Obtained credentials \($0)")
-    }
-    .onError {
-      print("Failed with \($0)")
-    }
-    .onCancel {
-      print("User cancelled")
-    }
-    .onPasswordless {
-      print("Passwordless requested for \($0)")
-    }
-    .present(from: self)
-```
+### Vulnerability reporting
 
-**Notes:**
-- Passwordless can only be used with a single connection and will prioritize the use of email connections over sms.  
+Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
 
-#### Passwordless method
+---
 
-When using Lock Passwordless the default `passwordlessMethod` is `.code` which sends the user a one time passcode to login. If you want to use [Universal Links](https://auth0.com/docs/dashboard/guides/applications/enable-universal-links) you can add the following:
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png" width="150">
+    <img alt="Auth0 Logo" src="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+  </picture>
+</p>
 
-```swift
-.withOptions {
-    $0.passwordlessMethod = .magicLink
-}
-```
+<p align="center">Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 
-#### Activity callback
-
-If you are using Lock Passwordless and have specified the `.magicLink` option to send the user a universal link then you will need to add the following to your `AppDelegate.swift`:
-
-```swift
-func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-    return Lock.continueAuth(using: userActivity)
-}
-```
-
-#### Adding a Passwordless connection
-
-##### SMS
-
-```swift
-.withConnections {
-    $0.sms(name: "sms")
-}
-```
-
-##### Email
-
-```swift
-.withConnections {
-    $0.email(name: "email")
-}
-```
-
-## Customization Options
-
-Lock provides numerous options to customize the Lock experience.
-
-#### Closable
-
-Allows Lock to be dismissed by the user. By default this is `false`.
-
-```swift
-.withOptions {
-    $0.closable = true
-}
-```
-
-#### Terms of Service
-
-By default Lock will use Auth0's [Terms of Service](https://auth0.com/web-terms) and [Privacy Policy](https://auth0.com/privacy):
-
-```swift
-.withOptions {
-    $0.termsOfService = "https://mycompany.com/terms"
-    $0.privacyPolicy = "https://mycompany.com/privacy"
-}
-```
-
-#### Must accept Terms of Service
-
-Database connection will require explicit acceptance of terms of service:
-
-```swift
-.withOptions {
-    $0.mustAcceptTerms = true
-}
-```
-
-#### Show Terms of Service
-
-Database connection will display the Terms & Service dialog. Default is `true`.
-
-```swift
-.withOptions {
-    $0.showTerms = true
-}
-```
-
-*Note: Terms will always be shown if the `mustAcceptTerms` flag has been enabled.*
-
-#### Logging
-
-* **logLevel**: By default this is `.off`, *Syslog* logging levels are supported.
-* **logHttpRequest**: Log Auth0.swift API requests. By default this is `false`
-* **loggerOutput**: Specify output handler, by default this uses the `print` statement.
-
-```swift
-.withOptions {
-    $0.logLevel = .all
-    $0.logHttpRequest = true
-    $0.loggerOutput = CleanroomLockLogger()
-}
-```
-
-In the code above, the *loggerOutput* has been set to use [CleanroomLogger](https://github.com/emaloney/CleanroomLogger).
-This can typically be achieved by implementing the *loggerOutput* protocol.  You can of course use your favorite logger library.
-
-```swift
-class CleanroomLockLogger: LoggerOutput {
-  func message(_ message: String, level: LoggerLevel, filename: String, line: Int) {
-    let channel: LogChannel?
-    switch level {
-    case .debug:
-        channel = Log.debug
-    case .error:
-        channel = Log.error
-    case .info:
-        channel = Log.info
-    case .verbose:
-        channel = Log.verbose
-    case .warn:
-        channel = Log.warning
-    default:
-        channel = nil
-    }
-    channel?.message(message, filePath: filename, fileLine: line)
-  }
-}
-```
-
-#### Scope
-
-Scope used for authentication. By default is `openid`. It will return not only the **access_token**, but also an **id_token** which is a [JSON Web Token (JWT)](https://jwt.io/) containing user information.
-
-```swift
-.withOptions {
-  $0.scope = "openid name email picture"
-}
-```
-
-#### Connection scope
-
-Allows you to set provider scopes for oauth2/social connections with a comma separated list. By default is empty.
-
-```swift
-.withOptions {
-  $0.connectionScope = ["facebook": "user_friends,email"]
-```
-
-#### Database
-
-- **allow**: Which database screens will be accessible, the default is enable all screens e.g. `.Login, .Signup, .ResetPassword`
-- **initialScreen**: The first screen to present to the user, the default is `.login`.
-- **usernameStyle**: Specify the type of identifier the login will require.  The default is either `[.Username, .Email]`.  However it's important to note that this option is only active if you have set the **requires_username** flag to `true` in your [Auth0 Dashboard](https://manage.auth0.com/#/)
-
-```swift
-.withOptions {
-  $0.allow = [.Login, .ResetPassword]
-  $0.initialScreen = .login
-  $0.usernameStyle = [.Username]
-}
-```
-
-#### Custom signup fields
-
-When signing up the default information requirements are the user's *email* and *password*. You can expand your data capture requirements as needed.
-
-If you want to save the value of the attribute in the root of a user's profile, ensure you set the  `storage` parameter to `.rootAttribute`. Only a subset of values can be stored this way. The list of attributes that can be added to your root profile is [here](https://auth0.com/docs/api/authentication#signup). By default, every additional sign up field is stored inside the user's `user_metadata` object.
-
-When signing up, your app may need to assign values to the user's profile that are not entered by the user. The `hidden` property of `CustomTextField` prevents the signup field from being shown to the user, allowing your app to assign default values to the user profile.
-
-
-```swift
-.withOptions {
-  $0.customSignupFields = [
-    CustomTextField(name: "first_name", placeholder: "First Name", storage: .rootAttribute, icon: UIImage(named: "ic_person", bundle: Lock.bundle), contentType: .givenName),
-    CustomTextField(name: "last_name", placeholder: "Last Name", storage: .rootAttribute, icon: UIImage(named: "ic_person", bundle: Lock.bundle), contentType: .familyName),
-    CustomTextField(name: "referral_code", placeholder: "Referral Code", defaultValue: referralCode, hidden: true)
-  ]
-}
-```
-
-*Note: You must specify the icon to use with your custom text field and store it in your App's bundle.*
-
-#### Password manager
-
-This functionality has been removed as of Release 2.18 due to the 1Password extension using deprecated methods, which can result in your app being rejected by the AppStore. This functionality was superseded in iOS 12 when Apple introduced the integration of password managers into login forms.
-
-The following options are now deprecated:
-
-```swift
-.withOptions {
-    $0.passwordManager.enabled = false
-    $0.passwordManager.appIdentifier = "www.myapp.com"
-    $0.passwordManager.displayName = "My App"
-}
-```
-
-You may also safely remove the following entry from your app's `Info.plist`:
-
-```xml
-<key>LSApplicationQueriesSchemes</key>
-<array>
-    <string>org-appextension-feature-password-management</string>
-</array>
-```
-
-#### Show password
-
-By default a show password icon is shown in password fields to toggle visibility of the input text. You can disable this using the `allowShowPassword` option:
-
-```swift
-.withOptions {
-    $0.allowShowPassword = false
-}
-```
-
-**Note:** Show password will not be available if the **Password Manager** is available.
-
-#### Enterprise
-
-* **enterpriseConnectionUsingActiveAuth**: By default Enterprise connections will use Web Authentication. However you can specify which connections will alternatively use credential authentication and prompt for a username and password.
-* **activeDirectoryEmailAsUsername**: When Lock request your enterprise credentials after performing Home Realm Discovery (HRD), e.g. for Active Directory, it will try to prefill the username for you. By default it will parse the email's local part and use that as the username, e.g. `john.doe@auth0.com` will be `john.doe`. If you don't want that you can turn on this flag and it will just use the email address.
-
-```swift
-.withOptions {
-  $0.activeDirectoryEmailAsUsername = true
-  $0.enterpriseConnectionUsingActiveAuth = ["enterprisedomain.com"]
-}
-```
-
-## What is Auth0?
-
-Auth0 helps you to:
-
-* Add authentication with [multiple sources](https://auth0.com/docs/identityproviders), either social identity providers such as **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce** (amongst others), or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS, or any SAML Identity Provider**.
-* Add authentication through more traditional **[username/password databases](https://auth0.com/docs/connections/database/custom-db)**.
-* Add support for **[linking different user accounts](https://auth0.com/docs/link-accounts)** with the same user.
-* Support for generating signed [JSON Web Tokens](https://auth0.com/docs/tokens/concepts/jwts) to call your APIs and **flow the user identity** securely.
-* Analytics of how, when, and where users are logging in.
-* Pull data from other sources and add it to the user profile through [JavaScript rules](https://auth0.com/docs/rules).
-
-## Create a Free Auth0 Account
-
-1. Go to [Auth0](https://auth0.com) and click **Sign Up**.
-2. Use Google, GitHub, or Microsoft Account to login.
-
-## Issue Reporting
-
-If you have found a bug or to request a feature, please [raise an issue](https://github.com/auth0/Lock.swift/issues). Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
-
-## Author
-
-[Auth0](https://auth0.com)
-
-## License
-
-This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
+<p align="center">This project is licensed under the MIT license. See the <a href="./LICENSE"> LICENSE</a> file for more info.</p>


### PR DESCRIPTION
### Changes

This PR incorporates the redesigned README, splitting the bulk of the documentation off into EXAMPLES.md. Also a  CONTRIBUTING.md file was added.

<img width="900" alt="Screen Shot 2022-10-24 at 23 37 32" src="https://user-images.githubusercontent.com/5055789/197669239-c851b393-0ac9-4b83-a015-105a8b155749.png">

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed