### PR TITLE
Fix links to `EXAMPLES.md` headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 
 **Learn how to use Lock.swift in [Examples ↗](EXAMPLES.md)**
 
-- [**Lock Classic**](EXAMPLES.md#lock-classic) - handles authentication using Database, Social, and Enterprise connections.
-- [**Lock Passwordless**](EXAMPLES.md#lock-passwordless) - handles authentication using Passwordless and Social connections.
+- [**Lock Classic**](https://github.com/auth0/Lock.swift/blob/master/EXAMPLES.md#lock-classic) - handles authentication using Database, Social, and Enterprise connections.
+- [**Lock Passwordless**](https://github.com/auth0/Lock.swift/blob/master/EXAMPLES.md#lock-passwordless) - handles authentication using Passwordless and Social connections.
 
 ## Feedback
 


### PR DESCRIPTION
### Changes

his PR turns the relative links to `EXAMPLES.md` headings into absolute ones, as GitHub won't route to the proper heading otherwise. That is, what works when tested with VS Code doesn't work once it's on GitHub.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed