### PR TITLE
Replace CleanroomLogger example with native os.Logger

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -22,8 +22,10 @@
 
 import UIKit
 import Lock
-import OSLog
+import os
 class ViewController: UIViewController {
+
+    private let logger = os.Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.auth0.lock", category: "ViewController")
 
     override func loadView() {
         let view = UIView()
@@ -183,21 +185,20 @@ class ViewController: UIViewController {
     }
 
     private func showLock(lock: Lock) {
-//        Log.enable(minimumSeverity: LogSeverity.verbose, debugMode: true)
-//        lock
-//            .onAuth { Log.info?.message("Obtained credentials \($0)") }
-//            .onError { Log.error?.message("Failed with \($0)") }
-//            .onSignUp { email, _ in  Log.debug?.message("New user \(email)") }
-//            .onCancel { Log.debug?.message("User closed lock") }
-//            .onPasswordless { Log.debug?.message("Passwordless requested for \($0)") }
-//            .present(from: self)
+        lock
+            .onAuth { [logger] in logger.info("Obtained credentials \($0)") }
+            .onError { [logger] in logger.error("Failed with \($0)") }
+            .onSignUp { [logger] email, _ in logger.debug("New user \(email)") }
+            .onCancel { [logger] in logger.debug("User closed lock") }
+            .onPasswordless { [logger] in logger.debug("Passwordless requested for \($0)") }
+            .present(from: self)
     }
 }
 
 func applyDefaultOptions(_ options: inout OptionBuildable) {
     options.closable = true
     options.logLevel = .all
-    options.loggerOutput = CleanroomLockLogger()
+    options.loggerOutput = OSLockLogger()
     options.logHttpRequest = true
     options.oidcConformant = true
 
@@ -266,24 +267,25 @@ func applyPhantomStyle(_ style: inout Style) {
     style.ruleTextColor = darkPurple
 }
 
-class CleanroomLockLogger: LoggerOutput {
+class OSLockLogger: LoggerOutput {
+
+    private let logger = os.Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.auth0.lock", category: "Lock")
 
     func message(_ message: String, level: LoggerLevel, filename: String, line: Int) {
-//        let channel: LogChannel?
-//        switch level {
-//        case .debug:
-//            channel = Log.debug
-//        case .error:
-//            channel = Log.error
-//        case .info:
-//            channel = Log.info
-//        case .verbose:
-//            channel = Log.verbose
-//        case .warn:
-//            channel = Log.warning
-//        default:
-//            channel = nil
-//        }
-//        channel?.message(message, filePath: filename, fileLine: line)
+        let osLevel: OSLogType
+        switch level {
+        case .error:
+            osLevel = .error
+        case .warn:
+            osLevel = .default
+        case .info:
+            osLevel = .info
+        case .debug, .verbose:
+            osLevel = .debug
+        default:
+            osLevel = .default
+        }
+        let filename = URL(fileURLWithPath: filename).lastPathComponent
+        logger.log(level: osLevel, "\(filename):\(line) - \(message)")
     }
 }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -284,32 +284,35 @@ Database connection will display the Terms of Service dialog. Defaults to `true`
 .withOptions {
     $0.logLevel = .all
     $0.logHttpRequest = true
-    $0.loggerOutput = CleanroomLockLogger()
+    $0.loggerOutput = OSLockLogger()
 }
 ```
 
-In the code above, the *loggerOutput* has been set to use [CleanroomLogger](https://github.com/emaloney/CleanroomLogger).
-This can typically be achieved by implementing the *loggerOutput* protocol.  You can of course use your favorite logger library.
+In the code above, the *loggerOutput* has been set to use Apple's native [unified logging system](https://developer.apple.com/documentation/os/logger) (`os.Logger`).
+This can typically be achieved by implementing the *loggerOutput* protocol. You can of course use your favorite logger library.
 
 ```swift
-class CleanroomLockLogger: LoggerOutput {
+import os
+
+class OSLockLogger: LoggerOutput {
+  private let logger = os.Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.auth0.lock", category: "Lock")
+
   func message(_ message: String, level: LoggerLevel, filename: String, line: Int) {
-    let channel: LogChannel?
+    let osLevel: OSLogType
     switch level {
-    case .debug:
-        channel = Log.debug
     case .error:
-        channel = Log.error
-    case .info:
-        channel = Log.info
-    case .verbose:
-        channel = Log.verbose
+        osLevel = .error
     case .warn:
-        channel = Log.warning
+        osLevel = .default
+    case .info:
+        osLevel = .info
+    case .debug, .verbose:
+        osLevel = .debug
     default:
-        channel = nil
+        osLevel = .default
     }
-    channel?.message(message, filePath: filename, fileLine: line)
+    let filename = URL(fileURLWithPath: filename).lastPathComponent
+    logger.log(level: osLevel, "\(filename):\(line) - \(message)")
   }
 }
 ```

--- a/Lock.xcodeproj/project.pbxproj
+++ b/Lock.xcodeproj/project.pbxproj
@@ -319,7 +319,6 @@
 		5C53A7F82703F48100A7C0A3 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
 		5C53A7F92703F48100A7C0A3 /* OHHTTPStubs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OHHTTPStubs.xcframework; path = Carthage/Build/OHHTTPStubs.xcframework; sourceTree = "<group>"; };
 		5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SimpleKeychain.xcframework; path = Carthage/Build/SimpleKeychain.xcframework; sourceTree = "<group>"; };
-		5C53A8012703F4AB00A7C0A3 /* CleanroomLogger.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CleanroomLogger.xcframework; path = Carthage/Build/CleanroomLogger.xcframework; sourceTree = "<group>"; };
 		5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = JWTDecode.xcframework; path = Carthage/Build/JWTDecode.xcframework; sourceTree = "<group>"; };
 		5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Auth0.xcframework; path = Carthage/Build/Auth0.xcframework; sourceTree = "<group>"; };
 		5F0FCF8F1E20117E00E3D53B /* ObserverStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverStore.swift; sourceTree = "<group>"; };
@@ -861,7 +860,6 @@
 			isa = PBXGroup;
 			children = (
 				5C53A8062703F4B900A7C0A3 /* Auth0.xcframework */,
-				5C53A8012703F4AB00A7C0A3 /* CleanroomLogger.xcframework */,
 				5C53A8022703F4AB00A7C0A3 /* JWTDecode.xcframework */,
 				5C53A8002703F4AB00A7C0A3 /* SimpleKeychain.xcframework */,
 				5C53A7F82703F48100A7C0A3 /* Nimble.xcframework */,


### PR DESCRIPTION
## Summary
- `CleanroomLogger` was dropped as a dependency a while back, leaving the example app's `loggerOutput` implementation and the `Lock` event callbacks in `showLock` entirely commented out — meaning `lock.present(from:)` was never even called.
- Renames `CleanroomLockLogger` to `OSLockLogger`, backed by Apple's native `os.Logger`, and restores the `onAuth`/`onError`/`onSignUp`/`onCancel`/`onPasswordless` logging through the same native API.
- Drops the now-orphaned `CleanroomLogger.xcframework` reference from the Xcode project (it wasn't linked into any build phase).
- Updates the logging section of `EXAMPLES.md` to match.

## Test plan
- [x] Typechecked the new `os.Logger`/`showLock` code against stub types mirroring Lock's real public API (`Lock`, `LoggerOutput`, `LoggerLevel`, `Credentials`) via `swiftc -typecheck`.
- [x] `swiftlint lint App/ViewController.swift` exits 0 (only pre-existing, unrelated warnings).
- [x] `plutil -lint Lock.xcodeproj/project.pbxproj` passes.